### PR TITLE
Fixes a bug with trailing newlines in toolchain path.

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -19,6 +19,7 @@ pub struct Toolchain<'a> {
 
 impl<'a> Toolchain<'a> {
 	pub fn from(cfg: &'a Cfg, name: &str) -> Self {
+        let name = name.trim_matches('\n');
 		Toolchain {
 			cfg: cfg,
 			name: name.to_owned(),


### PR DESCRIPTION
I was getting the following error when running cargo.

    error: not a directory: '/Users/ashkan/.multirust/toolchains/stable
    '

and noticed that the quote goes to the next line, so I added a trim to the
toolchain constructor for the only part that seemed to be problematic. Possibly
not the best solution, but it fixed my issue.