### PR TITLE
Build Linux binaries in an old CentOS 5 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ git:
   submodules: false
 
 sudo: required
+services:
+  - docker
 install:
   - git config --global user.email "diggsey@googlemail.com"
   - git config --global user.name "Diggory Blake (via Travis CI)"
@@ -23,15 +25,30 @@ install:
   - echo -e "\033[33;1mDownloading Rust\033[0m"
   - curl -sL http://static.rust-lang.org/dist/rust-nightly-$TARGET.tar.gz | tar --strip-components=1 -C ~/rust -xzf -
   - if [ "$TARGET" == "i686-unknown-linux-gnu" ]; then
+      sudo dpkg --add-architecture i386;
       sudo apt-get update;
-      sudo apt-get install libc6-dev:i386 libstdc++6:i386 zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386 gcc-multilib;
+      sudo apt-get install -y libc6-dev:i386 libstdc++6:i386 zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386 gcc-multilib;
     fi
   - echo -e "\033[33;1mInstalling Rust\033[0m"
   - sudo ~/rust/install.sh
 
 script:
-  - export OPENSSL_STATIC=1
-  - cargo build --release --verbose
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      docker run
+        --entrypoint bash
+        -u `id -u`:`id -g`
+        -v /usr/local:/usr/local:ro
+        -v `pwd`:/buildslave
+        -v $HOME:/home/rustbuild
+        -e HOME=/home/rustbuild
+        -e LD_LIBRARY_PATH=/usr/local/lib
+        -e OPENSSL_STATIC=1
+        -e OPENSSL_LIB_DIR=/rustroot/cargo$BITS/lib
+        -it alexcrichton/rust-slave-dist:2015-10-20b
+        -c "cargo build --release --verbose";
+    else
+      cargo build --release --verbose;
+    fi
   - find "target/release/" -maxdepth 1 -type f -exec sh -c 'sha256sum -b "{}" | cut -d\  -f1 > "{}.sha256"' \;
   - cargo test --verbose
   - tests/cli.sh


### PR DESCRIPTION
This should help the binaries be maximally compatible with older Linux releases
as they'll depend on a very old glibc. This also touches up the linkage to
openssl to be static on Linux and dynamic on OSX.

The docker image used here is currently the same one that we're using in
rust-lang/rust for the production of the nightly compilers.