### PR TITLE
Update openssl and hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ rust-install = { version = "0.0.4", path = "rust-install" }
 clap = "1.4.5"
 regex = "0.1.41"
 rand = "0.3.11"
-hyper = "0.6.14"
+openssl = "0.7.2"
+hyper = "0.7.0"
 term = "0.2.11"
 itertools = "0.4.1"
-openssl = "0.6.5"
 
 [target.x86_64-pc-windows-gnu.dependencies]
 winapi = "0.2.4"

--- a/rust-install/Cargo.toml
+++ b/rust-install/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT"
 [dependencies]
 regex = "0.1.41"
 rand = "0.3.11"
-hyper = "0.6.14"
-openssl = "0.6.5"
+hyper = "0.7.0"
+openssl = "0.7.2"
 itertools = "0.4.1"
 ole32-sys = "0.2.0"
 


### PR DESCRIPTION
The currently released version of multirust-rs is incompatible with other packages on crates.io which require newer hyper/openssl. This updates hyper and openssl to the latest versions. Consumers requiring the old versions can still depend on `0.0.4`, and those of us that require newer versions can use `0.0.5` :wink:.

Thanks!