### PR TITLE
Tests for transactions and manifest parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /rust-manifest/target
 /rust-manifest/Cargo.lock
 /.settings
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TARGET=i686-apple-darwin BITS=32 MACOSX_DEPLOYMENT_TARGET=10.7
     - os: osx
       env: TARGET=x86_64-apple-darwin BITS=64 MACOSX_DEPLOYMENT_TARGET=10.7
-  allow_failures:
-    - os: osx
 
 git:
   submodules: false

--- a/rust-install/src/component/components.rs
+++ b/rust-install/src/component/components.rs
@@ -199,10 +199,6 @@ impl<'a> AddingComponent<'a> {
         self.0.add(ComponentPart("file".to_owned(), path.clone()));
         self.1.add_file(&self.0.name, path)
     }
-    pub fn add_dir(&mut self, path: String) -> Result<()> {
-        self.0.add(ComponentPart("dir".to_owned(), path.clone()));
-        self.1.add_dir(&self.0.name, path)
-    }
     pub fn copy_file(&mut self, path: String, src: &Path) -> Result<()> {
         self.0.add(ComponentPart("file".to_owned(), path.clone()));
         self.1.copy_file(&self.0.name, path, src)
@@ -264,14 +260,14 @@ impl Component {
         // Remove parts
         for part in try!(self.parts()).into_iter().rev() {
             match &*part.0 {
-                "file" => try!(tx.remove_file(part.1)),
-                "dir" => try!(tx.remove_dir(part.1)),
+                "file" => try!(tx.remove_file(&self.name, part.1)),
+                "dir" => try!(tx.remove_dir(&self.name, part.1)),
                 _ => return Err(Error::CorruptComponent(self.name.clone())),
             }
         }
 
         // Remove component manifest
-        try!(tx.remove_file(self.rel_manifest_file()));
+        try!(tx.remove_file(&self.name, self.rel_manifest_file()));
 
         Ok(tx)
     }

--- a/rust-install/src/component/components.rs
+++ b/rust-install/src/component/components.rs
@@ -58,10 +58,10 @@ impl Components {
 
         Ok(c)
     }
-    fn rel_components_file(&self) -> String {
+    fn rel_components_file(&self) -> PathBuf {
         self.prefix.rel_manifest_file(COMPONENTS_FILE)
     }
-    fn rel_component_manifest(&self, name: &str) -> String {
+    fn rel_component_manifest(&self, name: &str) -> PathBuf {
         self.prefix.rel_manifest_file(&format!("manifest-{}", name))
     }
     fn read_version(&self) -> Result<Option<String>> {
@@ -195,29 +195,30 @@ impl<'a> AddingComponent<'a> {
 
         Ok((c, tx))
     }
-    pub fn add_file(&mut self, path: String) -> Result<File> {
+    pub fn add_file(&mut self, path: PathBuf) -> Result<File> {
         self.0.add(ComponentPart("file".to_owned(), path.clone()));
         self.1.add_file(&self.0.name, path)
     }
-    pub fn copy_file(&mut self, path: String, src: &Path) -> Result<()> {
+    pub fn copy_file(&mut self, path: PathBuf, src: &Path) -> Result<()> {
         self.0.add(ComponentPart("file".to_owned(), path.clone()));
         self.1.copy_file(&self.0.name, path, src)
     }
-    pub fn copy_dir(&mut self, path: String, src: &Path) -> Result<()> {
+    pub fn copy_dir(&mut self, path: PathBuf, src: &Path) -> Result<()> {
         self.0.add(ComponentPart("dir".to_owned(), path.clone()));
         self.1.copy_dir(&self.0.name, path, src)
     }
 }
 
-pub struct ComponentPart(pub String, pub String);
+pub struct ComponentPart(pub String, pub PathBuf);
 
 impl ComponentPart {
     pub fn encode(&self) -> String {
-        format!("{}:{}", &self.0, &self.1)
+        format!("{}:{:?}", &self.0, &self.1)
     }
     pub fn decode(line: &str) -> Option<Self> {
         line.find(":")
-            .map(|pos| ComponentPart(line[0..pos].to_owned(), line[(pos + 1)..].to_owned()))
+            .map(|pos| ComponentPart(line[0..pos].to_owned(),
+                                     PathBuf::from(&line[(pos + 1)..])))
     }
 }
 
@@ -234,7 +235,7 @@ impl Component {
     pub fn manifest_file(&self) -> PathBuf {
         self.components.prefix.manifest_file(&self.manifest_name())
     }
-    pub fn rel_manifest_file(&self) -> String {
+    pub fn rel_manifest_file(&self) -> PathBuf {
         self.components.prefix.rel_manifest_file(&self.manifest_name())
     }
     pub fn name(&self) -> &str {

--- a/rust-install/src/component/transaction.rs
+++ b/rust-install/src/component/transaction.rs
@@ -1,5 +1,15 @@
-// FIXME: This uses ensure_dir_exists in some places but rollback does
-// not remove any dirs created by it.
+//! A transactional interface to file system operations needed by the
+//! installer.
+//!
+//! Installation or uninstallation of a single component is done
+//! within a Transaction, which supports a few simple file system
+//! operations. If the Transaction is dropped without committing then
+//! it will *attempt* to roll back the transaction.
+//!
+//! FIXME: This uses ensure_dir_exists in some places but rollback
+//! does not remove any dirs created by it.
+//! FIXME: Paths passed here must be relative to the prefix. These
+//! should be Paths and asserted is_relative.
 
 use utils;
 use temp;
@@ -10,9 +20,141 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-// This is the set of fundamental operations supported on a Transaction. More complicated operations,
-// such as installing a package, or updating a component, distill down into a series of these
-// primitives.
+/// A Transaction tracks changes to the file system, allowing them to
+/// be rolled back in case of an error. Instead of deleting or
+/// overwriting file, the old copies are moved to a temporary
+/// folder. If the transaction is rolled back, they will be moved back
+/// into place. If the transaction is committed, these files are
+/// automatically cleaned up using the temp system.
+///
+/// All operations that create files will automatically create any
+/// intermediate directories in the path to the file if they do not
+/// already exist.
+///
+/// All operations that create files will fail if the destination
+/// already exists.
+pub struct Transaction<'a> {
+    prefix: InstallPrefix,
+    changes: Vec<ChangedItem<'a>>,
+    temp_cfg: &'a temp::Cfg,
+    notify_handler: NotifyHandler<'a>,
+    committed: bool,
+}
+
+impl<'a> Transaction<'a> {
+    pub fn new(prefix: InstallPrefix,
+               temp_cfg: &'a temp::Cfg,
+               notify_handler: NotifyHandler<'a>)
+               -> Self {
+        Transaction {
+            prefix: prefix,
+            changes: Vec::new(),
+            temp_cfg: temp_cfg,
+            notify_handler: notify_handler,
+            committed: false,
+        }
+    }
+
+    /// Commit must be called for all successful transactions. If not
+    /// called the transaction will be rolled back on drop.
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+
+    fn change(&mut self, item: ChangedItem<'a>) {
+        self.changes.push(item);
+    }
+
+    /// Add a file at a relative path to the install prefix. Returns a
+    /// `File` that may be used to subsequently write the
+    /// contents.
+    pub fn add_file(&mut self, component: &str, relpath: String) -> Result<File> {
+        let (item, file) = try!(ChangedItem::add_file(&self.prefix, component, relpath));
+        self.change(item);
+        Ok(file)
+    }
+
+    /// Copy a file to a relative path of the install prefix.
+    pub fn copy_file(&mut self, component: &str, relpath: String, src: &Path) -> Result<()> {
+        let item = try!(ChangedItem::copy_file(&self.prefix, component, relpath, src));
+        self.change(item);
+        Ok(())
+    }
+
+    /// Recursively copy a directory to a relative path of the install prefix.
+    pub fn copy_dir(&mut self, component: &str, relpath: String, src: &Path) -> Result<()> {
+        let item = try!(ChangedItem::copy_dir(&self.prefix, component, relpath, src));
+        self.change(item);
+        Ok(())
+    }
+
+    /// Remove a file from a relative path to the install prefix.
+    pub fn remove_file(&mut self, component: &str, relpath: String) -> Result<()> {
+        let item = try!(ChangedItem::remove_file(&self.prefix, component, relpath, &self.temp_cfg));
+        self.change(item);
+        Ok(())
+    }
+
+    /// Recursively remove a directory from a relative path of the
+    /// install prefix.
+    pub fn remove_dir(&mut self, component: &str, relpath: String) -> Result<()> {
+        let item = try!(ChangedItem::remove_dir(&self.prefix, component, relpath, &self.temp_cfg));
+        self.change(item);
+        Ok(())
+    }
+
+    /// Create a new file with string contents at a relative path to
+    /// the install prefix.
+    pub fn write_file(&mut self, component: &str, relpath: String, content: String) -> Result<()> {
+        let (item, mut file) = try!(ChangedItem::add_file(&self.prefix, component, relpath.clone()));
+        self.change(item);
+        try!(write!(file, "{}", content).map_err(|e| {
+            utils::Error::WritingFile {
+                name: "component",
+                path: self.prefix.abs_path(&relpath),
+                error: e,
+            }
+        }));
+        Ok(())
+    }
+
+    /// If the file exists back it up for rollback, otherwise ensure that the path
+    /// to it exists so that subsequent calls to `File::create` will succeed.
+    ///
+    /// This is used for arbitrarily manipulating a file.
+    pub fn modify_file(&mut self, relpath: String) -> Result<()> {
+        let item = try!(ChangedItem::modify_file(&self.prefix, relpath, &self.temp_cfg));
+        self.change(item);
+        Ok(())
+    }
+
+    pub fn temp(&self) -> &'a temp::Cfg {
+        self.temp_cfg
+    }
+    pub fn notify_handler(&self) -> NotifyHandler<'a> {
+        self.notify_handler
+    }
+}
+
+/// If a Transaction is dropped without being committed, the changes
+/// are automatically rolled back.
+impl<'a> Drop for Transaction<'a> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.notify_handler.call(Notification::RollingBack);
+            for item in self.changes.iter().rev() {
+                ok_ntfy!(self.notify_handler,
+                         Notification::NonFatalError,
+                         item.roll_back(&self.prefix));
+            }
+        }
+    }
+}
+
+/// This is the set of fundamental operations supported on a
+/// Transaction. More complicated operations, such as installing a
+/// package, or updating a component, distill down into a series of
+/// these primitives.
 enum ChangedItem<'a> {
     AddedFile(String),
     AddedDir(String),
@@ -35,7 +177,7 @@ impl<'a> ChangedItem<'a> {
                 try!(utils::rename_file("component", &tmp, &prefix.abs_path(path)))
             }
             RemovedDir(ref path, ref tmp) => {
-                try!(utils::rename_dir("component", &tmp, &prefix.abs_path(path)))
+                try!(utils::rename_dir("component", &tmp.join("bk"), &prefix.abs_path(path)))
             }
             ModifiedFile(ref path, None) => {
                 let abs_path = prefix.abs_path(path);
@@ -46,12 +188,12 @@ impl<'a> ChangedItem<'a> {
         }
         Ok(())
     }
-    fn add_file(prefix: &InstallPrefix, component: &str, path: String) -> Result<(Self, File)> {
-        let abs_path = prefix.abs_path(&path);
+    fn add_file(prefix: &InstallPrefix, component: &str, relpath: String) -> Result<(Self, File)> {
+        let abs_path = prefix.abs_path(&relpath);
         if utils::path_exists(&abs_path) {
             Err(Error::ComponentConflict {
                 name: component.to_owned(),
-                path: path.clone(),
+                path: relpath.clone(),
             })
         } else {
             if let Some(p) = abs_path.parent() {
@@ -64,182 +206,83 @@ impl<'a> ChangedItem<'a> {
                     error: e,
                 }
             }));
-            Ok((ChangedItem::AddedFile(path), file))
+            Ok((ChangedItem::AddedFile(relpath), file))
         }
     }
     fn copy_file(prefix: &InstallPrefix,
                  component: &str,
-                 path: String,
+                 relpath: String,
                  src: &Path)
                  -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
+        let abs_path = prefix.abs_path(&relpath);
         if utils::path_exists(&abs_path) {
             Err(Error::ComponentConflict {
                 name: component.to_owned(),
-                path: path.clone(),
+                path: relpath.clone(),
             })
         } else {
             if let Some(p) = abs_path.parent() {
                 try!(utils::ensure_dir_exists("component", p, utils::NotifyHandler::none()));
             }
             try!(utils::copy_file(src, &abs_path));
-            Ok(ChangedItem::AddedFile(path))
+            Ok(ChangedItem::AddedFile(relpath))
         }
     }
-    fn add_dir(prefix: &InstallPrefix, component: &str, path: String) -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
+    fn copy_dir(prefix: &InstallPrefix, component: &str, relpath: String, src: &Path) -> Result<Self> {
+        let abs_path = prefix.abs_path(&relpath);
         if utils::path_exists(&abs_path) {
             Err(Error::ComponentConflict {
                 name: component.to_owned(),
-                path: path.clone(),
-            })
-        } else {
-            try!(utils::ensure_dir_exists("component", &abs_path, utils::NotifyHandler::none()));
-            Ok(ChangedItem::AddedDir(path))
-        }
-    }
-    fn copy_dir(prefix: &InstallPrefix, component: &str, path: String, src: &Path) -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
-        if utils::path_exists(&abs_path) {
-            Err(Error::ComponentConflict {
-                name: component.to_owned(),
-                path: path.clone(),
+                path: relpath.clone(),
             })
         } else {
             if let Some(p) = abs_path.parent() {
                 try!(utils::ensure_dir_exists("component", p, utils::NotifyHandler::none()));
             }
             try!(utils::copy_dir(src, &abs_path, utils::NotifyHandler::none()));
-            Ok(ChangedItem::AddedDir(path))
+            Ok(ChangedItem::AddedDir(relpath))
         }
     }
-    fn remove_file(prefix: &InstallPrefix, path: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
+    fn remove_file(prefix: &InstallPrefix, component: &str, relpath: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
+        let abs_path = prefix.abs_path(&relpath);
         let backup = try!(temp_cfg.new_file());
-        try!(utils::rename_file("component", &abs_path, &backup));
-        Ok(ChangedItem::RemovedFile(path, backup))
+        if !utils::path_exists(&abs_path) {
+            Err(Error::ComponentMissingFile {
+                name: component.to_owned(),
+                path: relpath.clone(),
+            })
+        } else {
+            try!(utils::rename_file("component", &abs_path, &backup));
+            Ok(ChangedItem::RemovedFile(relpath, backup))
+        }
     }
-    fn remove_dir(prefix: &InstallPrefix, path: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
+    fn remove_dir(prefix: &InstallPrefix, component: &str, relpath: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
+        let abs_path = prefix.abs_path(&relpath);
         let backup = try!(temp_cfg.new_directory());
-        try!(utils::rename_dir("component", &abs_path, &backup));
-        Ok(ChangedItem::RemovedDir(path, backup))
+        if !utils::path_exists(&abs_path) {
+            Err(Error::ComponentMissingDir {
+                name: component.to_owned(),
+                path: relpath.clone(),
+            })
+        } else {
+            try!(utils::rename_dir("component", &abs_path, &backup.join("bk")));
+            Ok(ChangedItem::RemovedDir(relpath, backup))
+        }
     }
-    fn modify_file(prefix: &InstallPrefix, path: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
-        let abs_path = prefix.abs_path(&path);
+    fn modify_file(prefix: &InstallPrefix, relpath: String, temp_cfg: &'a temp::Cfg) -> Result<Self> {
+        let abs_path = prefix.abs_path(&relpath);
 
         if utils::is_file(&abs_path) {
             let backup = try!(temp_cfg.new_file());
             try!(utils::copy_file(&abs_path, &backup));
-            Ok(ChangedItem::ModifiedFile(path, Some(backup)))
+            Ok(ChangedItem::ModifiedFile(relpath, Some(backup)))
         } else {
             if let Some(p) = abs_path.parent() {
                 try!(utils::ensure_dir_exists("component", p, utils::NotifyHandler::none()));
             }
-            Ok(ChangedItem::ModifiedFile(path, None))
+            Ok(ChangedItem::ModifiedFile(relpath, None))
         }
     }
 }
 
 
-// A Transaction tracks changes to the file system, allowing them to be rolled back in case
-// of an error. Instead of deleting or overwriting file, the old copies are moved to a
-// temporary folder. If the transaction is rolled back, they will be moved back into place.
-// If the transaction is committed, these files are automatically cleaned up using the
-// temp system.
-pub struct Transaction<'a> {
-    prefix: InstallPrefix,
-    changes: Vec<ChangedItem<'a>>,
-    temp_cfg: &'a temp::Cfg,
-    notify_handler: NotifyHandler<'a>,
-    committed: bool,
-}
-
-impl<'a> Transaction<'a> {
-    pub fn new(prefix: InstallPrefix,
-               temp_cfg: &'a temp::Cfg,
-               notify_handler: NotifyHandler<'a>)
-               -> Self {
-        Transaction {
-            prefix: prefix,
-            changes: Vec::new(),
-            temp_cfg: temp_cfg,
-            notify_handler: notify_handler,
-            committed: false,
-        }
-    }
-    pub fn commit(mut self) {
-        self.committed = true;
-    }
-    fn change(&mut self, item: ChangedItem<'a>) {
-        self.changes.push(item);
-    }
-    pub fn add_file(&mut self, component: &str, path: String) -> Result<File> {
-        let (item, file) = try!(ChangedItem::add_file(&self.prefix, component, path));
-        self.change(item);
-        Ok(file)
-    }
-    pub fn copy_file(&mut self, component: &str, path: String, src: &Path) -> Result<()> {
-        let item = try!(ChangedItem::copy_file(&self.prefix, component, path, src));
-        self.change(item);
-        Ok(())
-    }
-    pub fn add_dir(&mut self, component: &str, path: String) -> Result<()> {
-        let item = try!(ChangedItem::add_dir(&self.prefix, component, path));
-        self.change(item);
-        Ok(())
-    }
-    pub fn copy_dir(&mut self, component: &str, path: String, src: &Path) -> Result<()> {
-        let item = try!(ChangedItem::copy_dir(&self.prefix, component, path, src));
-        self.change(item);
-        Ok(())
-    }
-    pub fn remove_file(&mut self, path: String) -> Result<()> {
-        let item = try!(ChangedItem::remove_file(&self.prefix, path, &self.temp_cfg));
-        self.change(item);
-        Ok(())
-    }
-    pub fn remove_dir(&mut self, path: String) -> Result<()> {
-        let item = try!(ChangedItem::remove_dir(&self.prefix, path, &self.temp_cfg));
-        self.change(item);
-        Ok(())
-    }
-    pub fn write_file(&mut self, component: &str, path: String, content: String) -> Result<()> {
-        let (item, mut file) = try!(ChangedItem::add_file(&self.prefix, component, path.clone()));
-        self.change(item);
-        try!(write!(file, "{}", content).map_err(|e| {
-            utils::Error::WritingFile {
-                name: "component",
-                path: self.prefix.abs_path(&path),
-                error: e,
-            }
-        }));
-        Ok(())
-    }
-    pub fn modify_file(&mut self, path: String) -> Result<()> {
-        let item = try!(ChangedItem::modify_file(&self.prefix, path, &self.temp_cfg));
-        self.change(item);
-        Ok(())
-    }
-    pub fn temp(&self) -> &'a temp::Cfg {
-        self.temp_cfg
-    }
-    pub fn notify_handler(&self) -> NotifyHandler<'a> {
-        self.notify_handler
-    }
-}
-
-// If a Transaction is dropped without being committed, the changes are automatically
-// rolled back.
-impl<'a> Drop for Transaction<'a> {
-    fn drop(&mut self) {
-        if !self.committed {
-            self.notify_handler.call(Notification::RollingBack);
-            for item in self.changes.iter().rev() {
-                ok_ntfy!(self.notify_handler,
-                         Notification::NonFatalError,
-                         item.roll_back(&self.prefix));
-            }
-        }
-    }
-}

--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -45,6 +45,14 @@ pub enum Error {
         name: String,
         path: String,
     },
+    ComponentMissingFile {
+        name: String,
+        path: String,
+    },
+    ComponentMissingDir {
+        name: String,
+        path: String,
+    },
     CorruptComponent(String),
     ExtractingPackage(io::Error),
     ExtensionNotFound(rust_manifest::Component),
@@ -135,6 +143,18 @@ impl Display for Error {
             ComponentConflict { ref name, ref path } => {
                 write!(f,
                        "failed to install component: '{}', detected conflict: '{}'",
+                       name,
+                       path)
+            }
+            ComponentMissingFile { ref name, ref path } => {
+                write!(f,
+                       "failure removing component '{}', file does not exist: '{}'",
+                       name,
+                       path)
+            }
+            ComponentMissingDir { ref name, ref path } => {
+                write!(f,
+                       "failure removing component '{}', directory does not exist: '{}'",
                        name,
                        path)
             }

--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -1,5 +1,5 @@
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::fmt::{self, Display};
 use std::io;
 use temp;
@@ -43,15 +43,15 @@ pub enum Error {
     },
     ComponentConflict {
         name: String,
-        path: String,
+        path: PathBuf,
     },
     ComponentMissingFile {
         name: String,
-        path: String,
+        path: PathBuf,
     },
     ComponentMissingDir {
         name: String,
-        path: String,
+        path: PathBuf,
     },
     CorruptComponent(String),
     ExtractingPackage(io::Error),
@@ -142,19 +142,19 @@ impl Display for Error {
             }
             ComponentConflict { ref name, ref path } => {
                 write!(f,
-                       "failed to install component: '{}', detected conflict: '{}'",
+                       "failed to install component: '{}', detected conflict: '{:?}'",
                        name,
                        path)
             }
             ComponentMissingFile { ref name, ref path } => {
                 write!(f,
-                       "failure removing component '{}', file does not exist: '{}'",
+                       "failure removing component '{}', file does not exist: '{:?}'",
                        name,
                        path)
             }
             ComponentMissingDir { ref name, ref path } => {
                 write!(f,
-                       "failure removing component '{}', directory does not exist: '{}'",
+                       "failure removing component '{}', directory does not exist: '{:?}'",
                        name,
                        path)
             }

--- a/rust-install/src/install.rs
+++ b/rust-install/src/install.rs
@@ -244,10 +244,10 @@ impl InstallPrefix {
         path.push(name);
         path
     }
-    pub fn rel_manifest_file(&self, name: &str) -> String {
+    pub fn rel_manifest_file(&self, name: &str) -> PathBuf {
         let mut path = PathBuf::from(REL_MANIFEST_DIR);
         path.push(name);
-        path.into_os_string().into_string().unwrap()
+        path
     }
     pub fn binary_file(&self, name: &str) -> PathBuf {
         let mut path = self.path.clone();

--- a/rust-install/tests/transactions.rs
+++ b/rust-install/tests/transactions.rs
@@ -1,0 +1,717 @@
+extern crate rust_install;
+extern crate tempdir;
+
+use rust_install::{InstallPrefix, InstallType, NotifyHandler};
+use rust_install::component::Transaction;
+use rust_install::{temp, utils};
+use rust_install::Error;
+use tempdir::TempDir;
+use std::fs;
+use std::io::Write;
+
+#[test]
+fn add_file() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let mut file = tx.add_file("c", "foo/bar".to_string()).unwrap();
+    write!(&mut file, "test").unwrap();
+
+    tx.commit();
+    drop(file);
+
+    assert_eq!(utils::raw::read_file(&prefix.path().join("foo/bar")).unwrap(),
+               "test");
+}
+
+#[test]
+fn add_file_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    tx.add_file("c", "foo/bar".to_string()).unwrap();
+    drop(tx);
+
+    assert!(!utils::is_file(prefix.path().join("foo/bar")));
+}
+
+#[test]
+fn add_file_that_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    fs::create_dir_all(&prefixdir.path().join("foo")).unwrap();
+    utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
+
+    let err = tx.add_file("c", "foo/bar".to_string()).unwrap_err();
+
+    match err {
+        Error::ComponentConflict { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "foo/bar");
+        }
+        _ => panic!()
+    }
+}
+
+#[test]
+fn copy_file() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let srcpath = srcdir.path().join("bar");
+    utils::write_file("", &srcpath, "").unwrap();
+
+    tx.copy_file("c", "foo/bar".to_string(), &srcpath).unwrap();
+    tx.commit();
+
+    assert!(utils::is_file(prefix.path().join("foo/bar")));
+}
+
+#[test]
+fn copy_file_then_rollback() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let srcpath = srcdir.path().join("bar");
+    utils::write_file("", &srcpath, "").unwrap();
+
+    tx.copy_file("c", "foo/bar".to_string(), &srcpath).unwrap();
+    drop(tx);
+
+    assert!(!utils::is_file(prefix.path().join("foo/bar")));
+}
+
+#[test]
+fn copy_file_that_exists() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let srcpath = srcdir.path().join("bar");
+    utils::write_file("", &srcpath, "").unwrap();
+
+    fs::create_dir_all(&prefixdir.path().join("foo")).unwrap();
+    utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
+
+    let err = tx.copy_file("c", "foo/bar".to_string(), &srcpath).unwrap_err();
+
+    match err {
+        Error::ComponentConflict { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "foo/bar");
+        }
+        _ => panic!()
+    }
+}
+
+#[test]
+fn copy_dir() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let srcpath1 = srcdir.path().join("foo");
+    let srcpath2 = srcdir.path().join("bar/baz");
+    let srcpath3 = srcdir.path().join("bar/qux/tickle");
+    utils::write_file("", &srcpath1, "").unwrap();
+    fs::create_dir_all(srcpath2.parent().unwrap()).unwrap();
+    utils::write_file("", &srcpath2, "").unwrap();
+    fs::create_dir_all(srcpath3.parent().unwrap()).unwrap();
+    utils::write_file("", &srcpath3, "").unwrap();
+
+    tx.copy_dir("c", "a".to_string(), srcdir.path()).unwrap();
+    tx.commit();
+
+    assert!(utils::is_file(prefix.path().join("a/foo")));
+    assert!(utils::is_file(prefix.path().join("a/bar/baz")));
+    assert!(utils::is_file(prefix.path().join("a/bar/qux/tickle")));
+}
+
+#[test]
+fn copy_dir_then_rollback() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let srcpath1 = srcdir.path().join("foo");
+    let srcpath2 = srcdir.path().join("bar/baz");
+    let srcpath3 = srcdir.path().join("bar/qux/tickle");
+    utils::write_file("", &srcpath1, "").unwrap();
+    fs::create_dir_all(srcpath2.parent().unwrap()).unwrap();
+    utils::write_file("", &srcpath2, "").unwrap();
+    fs::create_dir_all(srcpath3.parent().unwrap()).unwrap();
+    utils::write_file("", &srcpath3, "").unwrap();
+
+    tx.copy_dir("c", "a".to_string(), srcdir.path()).unwrap();
+    drop(tx);
+
+    assert!(!utils::is_file(prefix.path().join("a/foo")));
+    assert!(!utils::is_file(prefix.path().join("a/bar/baz")));
+    assert!(!utils::is_file(prefix.path().join("a/bar/qux/tickle")));
+}
+
+#[test]
+fn copy_dir_that_exists() {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    fs::create_dir_all(prefix.path().join("a")).unwrap();
+
+    let err = tx.copy_dir("c", "a".to_string(), srcdir.path()).unwrap_err();
+
+    match err {
+        Error::ComponentConflict { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "a");
+        }
+        _ => panic!()
+    }
+}
+
+#[test]
+fn remove_file() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let filepath = prefixdir.path().join("foo");
+    utils::write_file("", &filepath, "").unwrap();
+
+    tx.remove_file("c", "foo".to_string()).unwrap();
+    tx.commit();
+
+    assert!(!utils::is_file(filepath));
+}
+
+#[test]
+fn remove_file_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let filepath = prefixdir.path().join("foo");
+    utils::write_file("", &filepath, "").unwrap();
+
+    tx.remove_file("c", "foo".to_string()).unwrap();
+    drop(tx);
+
+    assert!(utils::is_file(filepath));
+}
+
+#[test]
+fn remove_file_that_not_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let err = tx.remove_file("c", "foo".to_string()).unwrap_err();
+
+    match err {
+        Error::ComponentMissingFile { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "foo");
+        }
+        _ => panic!()
+    }
+}
+
+#[test]
+fn remove_dir() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let filepath = prefixdir.path().join("foo/bar");
+    fs::create_dir_all(filepath.parent().unwrap()).unwrap();
+    utils::write_file("", &filepath, "").unwrap();
+
+    tx.remove_dir("c", "foo".to_string()).unwrap();
+    tx.commit();
+
+    assert!(!utils::path_exists(filepath.parent().unwrap()));
+}
+
+#[test]
+fn remove_dir_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let filepath = prefixdir.path().join("foo/bar");
+    fs::create_dir_all(filepath.parent().unwrap()).unwrap();
+    utils::write_file("", &filepath, "").unwrap();
+
+    tx.remove_dir("c", "foo".to_string()).unwrap();
+    drop(tx);
+
+    assert!(utils::path_exists(filepath.parent().unwrap()));
+}
+
+#[test]
+fn remove_dir_that_not_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let err = tx.remove_dir("c", "foo".to_string()).unwrap_err();
+
+    match err {
+        Error::ComponentMissingDir { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "foo");
+        }
+        _ => panic!()
+    }
+}
+
+#[test]
+fn write_file() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let content = "hi".to_string();
+    tx.write_file("c", "foo/bar".to_string(), content.clone()).unwrap();
+    tx.commit();
+
+    let path = prefix.path().join("foo/bar");
+    assert!(utils::is_file(&path));
+    let file_content = utils::raw::read_file(&path).unwrap();
+    assert_eq!(content, file_content);
+}
+
+#[test]
+fn write_file_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let content = "hi".to_string();
+    tx.write_file("c", "foo/bar".to_string(), content.clone()).unwrap();
+    drop(tx);
+
+    assert!(!utils::is_file(&prefix.path().join("foo/bar")));
+}
+
+#[test]
+fn write_file_that_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let content = "hi".to_string();
+    utils::raw::write_file(&prefix.path().join("a"), &content).unwrap();
+    let err = tx.write_file("c", "a".to_string(), content.clone()).unwrap_err();
+
+    match err {
+        Error::ComponentConflict { name, path } => {
+            assert_eq!(name, "c");
+            assert_eq!(path, "a");
+        }
+        _ => panic!()
+    }
+}
+
+// If the file does not exist, then the path to it is created,
+// but the file is not.
+#[test]
+fn modify_file_that_not_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    tx.modify_file("foo/bar".to_string()).unwrap();
+    tx.commit();
+
+    assert!(utils::path_exists(prefix.path().join("foo")));
+    assert!(!utils::path_exists(prefix.path().join("foo/bar")));
+}
+
+// If the file does exist, then it's just backed up
+#[test]
+fn modify_file_that_exists() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let ref path = prefix.path().join("foo");
+    utils::raw::write_file(path, "wow").unwrap();
+    tx.modify_file("foo".to_string()).unwrap();
+    tx.commit();
+
+    assert_eq!(utils::raw::read_file(path).unwrap(), "wow");
+}
+
+#[test]
+fn modify_file_that_not_exists_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    tx.modify_file("foo/bar".to_string()).unwrap();
+    drop(tx);
+
+    assert!(!utils::path_exists(prefix.path().join("foo/bar")));
+}
+
+#[test]
+fn modify_file_that_exists_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let ref path = prefix.path().join("foo");
+    utils::raw::write_file(path, "wow").unwrap();
+    tx.modify_file("foo".to_string()).unwrap();
+    utils::raw::write_file(path, "eww").unwrap();
+    drop(tx);
+
+    assert_eq!(utils::raw::read_file(path).unwrap(), "wow");
+}
+
+// This is testing that the backup scheme is smart enough not
+// to overwrite the earliest backup.
+#[test]
+fn modify_twice_then_rollback() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    let ref path = prefix.path().join("foo");
+    utils::raw::write_file(path, "wow").unwrap();
+    tx.modify_file("foo".to_string()).unwrap();
+    utils::raw::write_file(path, "eww").unwrap();
+    tx.modify_file("foo".to_string()).unwrap();
+    utils::raw::write_file(path, "ewww").unwrap();
+    drop(tx);
+
+    assert_eq!(utils::raw::read_file(path).unwrap(), "wow");
+}
+
+fn do_multiple_op_transaction(rollback: bool) {
+    let srcdir = TempDir::new("multirust").unwrap();
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    // copy_file
+    let relpath1 = "bin/rustc".to_string();
+    let relpath2 = "bin/cargo".to_string();
+    // copy_dir
+    let relpath4 = "doc/html/index.html".to_string();
+    // modify_file
+    let relpath5 = "lib/rustlib/components".to_string();
+    // write_file
+    let relpath6 = "lib/rustlib/rustc-manifest.in".to_string();
+    // remove_file
+    let relpath7 = "bin/oldrustc".to_string();
+    // remove_dir
+    let relpath8 = "olddoc/htm/index.html".to_string();
+
+    let ref path1 = prefix.path().join(&relpath1);
+    let ref path2 = prefix.path().join(&relpath2);
+    let ref path4 = prefix.path().join(&relpath4);
+    let ref path5 = prefix.path().join(&relpath5);
+    let ref path6 = prefix.path().join(&relpath6);
+    let ref path7 = prefix.path().join(&relpath7);
+    let ref path8 = prefix.path().join(&relpath8);
+
+    let ref srcpath1 = srcdir.path().join(&relpath1);
+    fs::create_dir_all(srcpath1.parent().unwrap()).unwrap();
+    utils::raw::write_file(srcpath1, "").unwrap();
+    tx.copy_file("", relpath1, srcpath1).unwrap();
+
+    let ref srcpath2 = srcdir.path().join(&relpath2);
+    utils::raw::write_file(srcpath2, "").unwrap();
+    tx.copy_file("", relpath2, srcpath2).unwrap();
+
+    let ref srcpath4 = srcdir.path().join(&relpath4);
+    fs::create_dir_all(srcpath4.parent().unwrap()).unwrap();
+    utils::raw::write_file(srcpath4, "").unwrap();
+    tx.copy_dir("", "doc".to_string(), &srcdir.path().join("doc")).unwrap();
+
+    tx.modify_file(relpath5).unwrap();
+    utils::raw::write_file(path5, "").unwrap();
+
+    tx.write_file("", relpath6, "".to_string()).unwrap();
+
+    fs::create_dir_all(path7.parent().unwrap()).unwrap();
+    utils::raw::write_file(path7, "").unwrap();
+    tx.remove_file("", relpath7).unwrap();
+
+    fs::create_dir_all(path8.parent().unwrap()).unwrap();
+    utils::raw::write_file(path8, "").unwrap();
+    tx.remove_dir("", "olddoc".to_string()).unwrap();
+
+    if !rollback {
+        tx.commit();
+
+        assert!(utils::path_exists(path1));
+        assert!(utils::path_exists(path2));
+        assert!(utils::path_exists(path4));
+        assert!(utils::path_exists(path5));
+        assert!(utils::path_exists(path6));
+        assert!(!utils::path_exists(path7));
+        assert!(!utils::path_exists(path8));
+    } else {
+        drop(tx);
+
+        assert!(!utils::path_exists(path1));
+        assert!(!utils::path_exists(path2));
+        assert!(!utils::path_exists(path4));
+        assert!(!utils::path_exists(path5));
+        assert!(!utils::path_exists(path6));
+        assert!(utils::path_exists(path7));
+        assert!(utils::path_exists(path8));
+    }
+}
+
+#[test]
+fn multiple_op_transaction() {
+    do_multiple_op_transaction(false);
+}
+
+#[test]
+fn multiple_op_transaction_then_rollback() {
+    do_multiple_op_transaction(true);
+}
+
+// Even if one step fails to rollback, rollback should
+// continue to rollback other steps.
+#[test]
+fn rollback_failure_keeps_going() {
+    let prefixdir = TempDir::new("multirust").unwrap();
+    let txdir = TempDir::new("multirust").unwrap();
+
+    let tmpnotify = temp::SharedNotifyHandler::none();
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), tmpnotify);
+
+    let prefix = InstallPrefix::from(prefixdir.path().to_owned(),
+                                     InstallType::Owned);
+
+    let notify = NotifyHandler::none();
+    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, notify);
+
+    write!(&mut tx.add_file("", "foo".to_string()).unwrap(), "").unwrap();
+    write!(&mut tx.add_file("", "bar".to_string()).unwrap(), "").unwrap();
+    write!(&mut tx.add_file("", "baz".to_string()).unwrap(), "").unwrap();
+
+    fs::remove_file(prefix.path().join("bar")).unwrap();
+
+    drop(tx);
+
+    assert!(!utils::path_exists(prefix.path().join("foo")));
+    assert!(!utils::path_exists(prefix.path().join("baz")));
+}
+
+// Test that when a transaction creates intermediate directories that
+// they are deleted during rollback.
+#[test]
+#[ignore]
+fn intermediate_dir_rollback() {
+}

--- a/rust-manifest/src/utils.rs
+++ b/rust-manifest/src/utils.rs
@@ -15,6 +15,16 @@ pub fn get_string(table: &mut toml::Table, key: &str, path: &str) -> Result<Stri
     })
 }
 
+pub fn get_bool(table: &mut toml::Table, key: &str, path: &str) -> Result<bool> {
+    get_value(table, key, path).and_then(|v| {
+        if let toml::Value::Boolean(b) = v {
+            Ok(b)
+        } else {
+            Err(Error::ExpectedType("string", path.to_owned() + key))
+        }
+    })
+}
+
 pub fn get_opt_string(table: &mut toml::Table, key: &str, path: &str) -> Result<Option<String>> {
     if let Some(v) = table.remove(key) {
         if let toml::Value::String(s) = v {

--- a/rust-manifest/tests/channel-rust-nightly-example.toml
+++ b/rust-manifest/tests/channel-rust-nightly-example.toml
@@ -1,0 +1,52 @@
+manifest-version = "2"
+date = "2015-10-10"
+[pkg.rust]
+  version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+  [pkg.rust.target.x86_64-unknown-linux-gnu]
+    available = true
+    url = "example.com"
+    hash = "..."
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+      pkg = "rustc"
+      target = "x86_64-unknown-linux-gnu"
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+      pkg = "rust-docs"
+      target = "x86_64-unknown-linux-gnu"
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+      pkg = "cargo"
+      target = "x86_64-unknown-linux-gnu"
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+      pkg = "rust-std"
+      target = "x86_64-unknown-linux-gnu"
+    # extensions are rust-std or rust-docs that aren't in the rust tarball's component list
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+      pkg = "rust-std"
+      target = "x86_64-unknown-linux-musl"
+    [[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+      pkg = "rust-std"
+      target = "i686-unknown-linux-gnu"
+[pkg.rustc]
+  version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+  [pkg.rustc.target.x86_64-unknown-linux-gnu]
+    available = true
+    url = "example.com"
+    hash = "..."
+[pkg.cargo]
+  version = "cargo 0.4.0-nightly (553b363 2015-08-03)"
+  [pkg.cargo.target.x86_64-unknown-linux-gnu]
+    available = true
+    url = "example.com"
+    hash = "..."
+[pkg.rust-std]
+  version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+  [pkg.rust-std.target.x86_64-unknown-linux-gnu]
+    available = true
+    url = "example.com"
+    hash = "..."
+[pkg.rust-docs]
+  version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+  [pkg.rust-docs.target.x86_64-unknown-linux-gnu]
+    available = true
+    url = "example.com"
+    hash = "..."
+

--- a/rust-manifest/tests/manifest.rs
+++ b/rust-manifest/tests/manifest.rs
@@ -1,0 +1,46 @@
+extern crate rust_manifest;
+
+use rust_manifest::Manifest;
+
+// Example manifest from https://public.etherpad-mozilla.org/p/Rust-infra-work-week
+static EXAMPLE: &'static str = include_str!("channel-rust-nightly-example.toml");
+
+#[test]
+fn parse_smoke_test() {
+    let pkg = Manifest::parse(EXAMPLE).unwrap();
+
+    pkg.get_package("rust").unwrap();
+    pkg.get_package("rustc").unwrap();
+    pkg.get_package("cargo").unwrap();
+    pkg.get_package("rust-std").unwrap();
+    pkg.get_package("rust-docs").unwrap();
+
+    let rust_pkg = pkg.get_package("rust").unwrap();
+    assert!(rust_pkg.version.contains("1.3.0"));
+
+    let rust_target_pkg = rust_pkg.get_target("x86_64-unknown-linux-gnu").unwrap();
+    assert_eq!(rust_target_pkg.available, true);
+    assert_eq!(rust_target_pkg.url, "example.com");
+    assert_eq!(rust_target_pkg.hash, "...");
+
+    let ref component = rust_target_pkg.components[0];
+    assert_eq!(component.pkg, "rustc");
+    assert_eq!(component.target, "x86_64-unknown-linux-gnu");
+
+    let ref component = rust_target_pkg.extensions[0];
+    assert_eq!(component.pkg, "rust-std");
+    assert_eq!(component.target, "x86_64-unknown-linux-musl");
+
+    let docs_pkg = pkg.get_package("rust-docs").unwrap();
+    let docs_target_pkg = docs_pkg.get_target("x86_64-unknown-linux-gnu").unwrap();
+    assert_eq!(docs_target_pkg.url, "example.com");
+}
+
+#[test]
+fn parse_round_trip() {
+    let original = Manifest::parse(EXAMPLE).unwrap();
+    let serialized = original.clone().stringify();
+    let new = Manifest::parse(&serialized).unwrap();
+    assert_eq!(original, new);
+}
+


### PR DESCRIPTION
Here are tests for the Transaction type and Manifest serialization.

I fixed some bugs along the way: copy_dir failing on windows, manifests not serializing correctly, probably others. Brought the manifest definition up to date with what I think it is going to look like.

I also reorganized some of the code I was working off of to read top-down because I find it easier to understand, so e.g. I put constructors first in impls and the `Transaction` type ahead of the `ChangedItem` type. This makes the diff harder to read. Sorry.

Now I'm working to understand how these pieces tie together to install components from the dist server, and writing integration tests with a local mock dist server.