### PR TITLE
Implement fmt::Debug on all types

### DIFF
--- a/rust-install/src/component/components.rs
+++ b/rust-install/src/component/components.rs
@@ -7,7 +7,7 @@ use install::InstallPrefix;
 use errors::*;
 
 use component::transaction::Transaction;
-use component::package::{PackageDebug, INSTALLER_VERSION, VERSION_FILE};
+use component::package::{Package, INSTALLER_VERSION, VERSION_FILE};
 
 use std::path::{Path, PathBuf};
 use std::fs::File;
@@ -17,7 +17,7 @@ const COMPONENTS_FILE: &'static str = "components";
 
 #[derive(Debug)]
 pub struct ChangeSet<'a> {
-    pub packages: Vec<Box<PackageDebug + 'a>>,
+    pub packages: Vec<Box<Package + 'a>>,
     pub to_install: Vec<String>,
     pub to_uninstall: Vec<String>,
 }
@@ -36,7 +36,7 @@ impl<'a> ChangeSet<'a> {
     pub fn uninstall(&mut self, component: String) {
         self.to_uninstall.push(component);
     }
-    pub fn add_package<P: PackageDebug + 'a>(&mut self, package: P) {
+    pub fn add_package<P: Package + 'a>(&mut self, package: P) {
         self.packages.push(Box::new(package));
     }
 }

--- a/rust-install/src/component/components.rs
+++ b/rust-install/src/component/components.rs
@@ -7,7 +7,7 @@ use install::InstallPrefix;
 use errors::*;
 
 use component::transaction::Transaction;
-use component::package::{Package, INSTALLER_VERSION, VERSION_FILE};
+use component::package::{PackageDebug, INSTALLER_VERSION, VERSION_FILE};
 
 use std::path::{Path, PathBuf};
 use std::fs::File;
@@ -15,8 +15,9 @@ use std::io::Write;
 
 const COMPONENTS_FILE: &'static str = "components";
 
+#[derive(Debug)]
 pub struct ChangeSet<'a> {
-    pub packages: Vec<Box<Package + 'a>>,
+    pub packages: Vec<Box<PackageDebug + 'a>>,
     pub to_install: Vec<String>,
     pub to_uninstall: Vec<String>,
 }
@@ -35,7 +36,7 @@ impl<'a> ChangeSet<'a> {
     pub fn uninstall(&mut self, component: String) {
         self.to_uninstall.push(component);
     }
-    pub fn add_package<P: Package + 'a>(&mut self, package: P) {
+    pub fn add_package<P: PackageDebug + 'a>(&mut self, package: P) {
         self.packages.push(Box::new(package));
     }
 }
@@ -143,6 +144,7 @@ impl Components {
     }
 }
 
+#[derive(Debug)]
 struct ComponentBuilder {
     components: Components,
     name: String,
@@ -185,6 +187,7 @@ impl ComponentBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct AddingComponent<'a>(ComponentBuilder, Transaction<'a>);
 
 impl<'a> AddingComponent<'a> {
@@ -209,6 +212,7 @@ impl<'a> AddingComponent<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct ComponentPart(pub String, pub PathBuf);
 
 impl ComponentPart {
@@ -222,7 +226,7 @@ impl ComponentPart {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Component {
     components: Components,
     name: String,

--- a/rust-install/src/component/package.rs
+++ b/rust-install/src/component/package.rs
@@ -22,7 +22,7 @@ use std::fs::File;
 pub const INSTALLER_VERSION: &'static str = "3";
 pub const VERSION_FILE: &'static str = "rust-installer-version";
 
-pub trait Package {
+pub trait Package: fmt::Debug {
     fn contains(&self, component: &str, short_name: Option<&str>) -> bool;
     fn install<'a>(&self,
                    target: &Components,
@@ -31,9 +31,6 @@ pub trait Package {
                    tx: Transaction<'a>)
                    -> Result<Transaction<'a>>;
 }
-
-pub trait PackageDebug: Package + fmt::Debug {}
-impl<T: Package + fmt::Debug> PackageDebug for T {}
 
 #[derive(Debug)]
 pub struct DirectoryPackage {

--- a/rust-install/src/component/package.rs
+++ b/rust-install/src/component/package.rs
@@ -14,6 +14,7 @@ use temp;
 
 use std::path::{Path, PathBuf};
 use std::collections::HashSet;
+use std::fmt;
 use std::io::Read;
 use std::fs::File;
 
@@ -31,6 +32,10 @@ pub trait Package {
                    -> Result<Transaction<'a>>;
 }
 
+pub trait PackageDebug: Package + fmt::Debug {}
+impl<T: Package + fmt::Debug> PackageDebug for T {}
+
+#[derive(Debug)]
 pub struct DirectoryPackage {
     path: PathBuf,
     components: HashSet<String>,
@@ -163,6 +168,7 @@ fn set_file_perms(_dest_path: &Path, _src_path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
 
 impl<'a> TarPackage<'a> {
@@ -190,6 +196,7 @@ impl<'a> Package for TarPackage<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct TarGzPackage<'a>(TarPackage<'a>);
 
 impl<'a> TarGzPackage<'a> {

--- a/rust-install/src/component/transaction.rs
+++ b/rust-install/src/component/transaction.rs
@@ -31,6 +31,7 @@ use std::path::{Path, PathBuf};
 ///
 /// All operations that create files will fail if the destination
 /// already exists.
+#[derive(Debug)]
 pub struct Transaction<'a> {
     prefix: InstallPrefix,
     changes: Vec<ChangedItem<'a>>,
@@ -160,6 +161,7 @@ impl<'a> Drop for Transaction<'a> {
 /// Transaction. More complicated operations, such as installing a
 /// package, or updating a component, distill down into a series of
 /// these primitives.
+#[derive(Debug)]
 enum ChangedItem<'a> {
     AddedFile(PathBuf),
     AddedDir(PathBuf),

--- a/rust-install/src/configured/mod.rs
+++ b/rust-install/src/configured/mod.rs
@@ -8,6 +8,7 @@ use manifest;
 
 pub const CONFIG_FILE: &'static str = "config.toml";
 
+#[derive(Debug)]
 pub struct Configuration {
     prefix: InstallPrefix,
     config: Config,

--- a/rust-install/src/dist.rs
+++ b/rust-install/src/dist.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 pub const DEFAULT_DIST_ROOT: &'static str = "https://static.rust-lang.org/dist";
 pub const UPDATE_HASH_LEN: usize = 20;
 
+#[derive(Debug)]
 pub struct ToolchainDesc {
     pub arch: Option<String>,
     pub os: Option<String>,
@@ -106,6 +107,7 @@ impl ToolchainDesc {
     }
 }
 
+#[derive(Debug)]
 pub struct Manifest<'a>(temp::File<'a>, String);
 
 impl<'a> Manifest<'a> {
@@ -197,7 +199,7 @@ pub fn download_and_check<'a>(url_str: &str,
     Ok(Some((file, partial_hash)))
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct DownloadCfg<'a> {
     pub dist_root: &'a str,
     pub temp_cfg: &'a temp::Cfg,

--- a/rust-install/src/download.rs
+++ b/rust-install/src/download.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use std::path::Path;
 use std::process::Command;
 
+#[derive(Debug)]
 pub struct DownloadCfg<'a> {
     pub temp_cfg: &'a temp::Cfg,
     pub notify_handler: NotifyHandler<'a>,

--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -9,6 +9,7 @@ use walkdir;
 
 use notify::{NotificationLevel, Notifyable};
 
+#[derive(Debug)]
 pub enum Notification<'a> {
     Utils(utils::Notification<'a>),
     Temp(temp::Notification<'a>),

--- a/rust-install/src/install.rs
+++ b/rust-install/src/install.rs
@@ -38,6 +38,7 @@ pub enum InstallType {
     Shared,
 }
 
+#[derive(Debug)]
 pub enum Uninstaller {
     Sh(PathBuf),
     Msi(String),
@@ -57,6 +58,7 @@ impl Uninstaller {
     }
 }
 
+#[derive(Debug)]
 pub enum InstallMethod<'a> {
     Copy(&'a Path),
     Link(&'a Path),

--- a/rust-install/src/lib.rs
+++ b/rust-install/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(core_intrinsics)] // For type_name().
 #![feature(fundamental)]
 
 extern crate rand;

--- a/rust-install/src/manifest/mod.rs
+++ b/rust-install/src/manifest/mod.rs
@@ -8,6 +8,7 @@ use install::InstallPrefix;
 use openssl::crypto::hash::{Type, Hasher};
 use itertools::Itertools;
 
+#[derive(Debug)]
 pub struct Changes {
     pub add_extensions: Vec<Component>,
     pub remove_extensions: Vec<Component>,
@@ -25,6 +26,7 @@ impl Changes {
 pub const DIST_MANIFEST: &'static str = "dist.toml";
 pub const PACKAGES_MANIFEST: &'static str = "packages.toml";
 
+#[derive(Debug)]
 pub struct Manifestation(Components);
 
 impl Manifestation {

--- a/rust-install/src/msi.rs
+++ b/rust-install/src/msi.rs
@@ -7,9 +7,12 @@ use std::io;
 use std::iter;
 use std::path::PathBuf;
 
+#[derive(Debug)]
 pub struct Installers(RegKey);
+#[derive(Debug)]
 pub struct AllInstallers(Installers, Installers);
 
+#[derive(Debug)]
 pub struct Installer {
     id: String,
     key: RegKey,

--- a/rust-install/src/notify.rs
+++ b/rust-install/src/notify.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+use std::intrinsics::type_name;
 use std::sync::Arc;
 
 #[fundamental]
@@ -11,9 +13,14 @@ impl<N, F: ?Sized + Fn(N)> Notifyable<N> for F {
     }
 }
 
-#[derive(Debug)]
 #[fundamental]
 pub struct NotifyHandler<'a, T: 'a + ?Sized>(Option<&'a T>);
+
+impl<'a, T: 'a + ?Sized> fmt::Debug for NotifyHandler<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+	write!(f, "NotifyHandler<{}>", unsafe { type_name::<T>() })
+    }
+}
 
 impl<'a, T: 'a + ?Sized> Copy for NotifyHandler<'a, T> {}
 impl<'a, T: 'a + ?Sized> Clone for NotifyHandler<'a, T> {
@@ -22,13 +29,18 @@ impl<'a, T: 'a + ?Sized> Clone for NotifyHandler<'a, T> {
     }
 }
 
-#[derive(Debug)]
 #[fundamental]
 pub struct SharedNotifyHandler<T: ?Sized>(Option<Arc<T>>);
 
 impl<T: ?Sized> Clone for SharedNotifyHandler<T> {
     fn clone(&self) -> Self {
         SharedNotifyHandler(self.0.clone())
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for SharedNotifyHandler<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+	write!(f, "SharedNotifyHandler<{}>", unsafe { type_name::<T>() })
     }
 }
 

--- a/rust-install/src/temp.rs
+++ b/rust-install/src/temp.rs
@@ -27,6 +27,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub type NotifyHandler<'a> = notify::NotifyHandler<'a, for<'b> Notifyable<Notification<'b>>>;
 pub type SharedNotifyHandler = notify::SharedNotifyHandler<for<'b> Notifyable<Notification<'b>>>;
 
+#[derive(Debug)]
 pub enum Notification<'a> {
     CreatingRoot(&'a Path),
     CreatingFile(&'a Path),
@@ -35,16 +36,19 @@ pub enum Notification<'a> {
     DirectoryDeletion(&'a Path, io::Result<()>),
 }
 
+#[derive(Debug)]
 pub struct Cfg {
     root_directory: PathBuf,
     notify_handler: SharedNotifyHandler,
 }
 
+#[derive(Debug)]
 pub struct Dir<'a> {
     cfg: &'a Cfg,
     path: PathBuf,
 }
 
+#[derive(Debug)]
 pub struct File<'a> {
     cfg: &'a Cfg,
     path: PathBuf,

--- a/rust-install/src/utils/mod.rs
+++ b/rust-install/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub mod raw;
 pub use self::raw::{is_directory, is_file, path_exists, if_not_empty, random_string, prefix_arg,
                     home_dir, has_cmd, find_cmd};
 
+#[derive(Debug)]
 pub enum Notification<'a> {
     CreatingDirectory(&'a str, &'a Path),
     LinkingDirectory(&'a Path, &'a Path),

--- a/rust-install/tests/install.rs
+++ b/rust-install/tests/install.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use tempdir::TempDir;
 
 // Mock of the on-disk structure of rust-installer installers
+#[derive(Debug)]
 struct MockInstallerBuilder {
     components: Vec<MockComponent>,
 }
@@ -21,6 +22,7 @@ struct MockInstallerBuilder {
 // (either "file:" or "dir:") and the file paths and contents.
 type MockComponent = (&'static str, Vec<Command>, Vec<(&'static str, &'static str)>);
 
+#[derive(Debug)]
 enum Command {
     File(&'static str),
     Dir(&'static str)

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use toolchain::Toolchain;
 
 pub const METADATA_VERSION: &'static str = "2";
 
+#[derive(Debug)]
 pub enum OverrideReason {
     Environment,
     OverrideDB(PathBuf),
@@ -31,6 +32,7 @@ impl Display for OverrideReason {
     }
 }
 
+#[derive(Debug)]
 pub struct Cfg {
     pub multirust_dir: PathBuf,
     pub version_file: PathBuf,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display};
 use rust_install::{self, utils, temp};
 use rust_install::notify::{self, NotificationLevel, Notifyable};
 
+#[derive(Debug)]
 pub enum Notification<'a> {
     Install(rust_install::Notification<'a>),
     Utils(utils::Notification<'a>),
@@ -26,6 +27,7 @@ pub enum Notification<'a> {
     NonFatalError(&'a Error),
 }
 
+#[derive(Debug)]
 pub enum Error {
     Install(rust_install::Error),
     Utils(utils::Error),

--- a/src/override_db.rs
+++ b/src/override_db.rs
@@ -5,6 +5,7 @@ use rust_install::{utils, temp};
 
 pub const DB_DELIMITER: &'static str = ";";
 
+#[derive(Debug)]
 pub struct OverrideDB(PathBuf);
 
 impl OverrideDB {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use hyper;
 use rust_install;
 
+#[derive(Debug)]
 pub struct Toolchain<'a> {
     cfg: &'a Cfg,
     name: String,


### PR DESCRIPTION
This vastly increases ease of experimentation with the libraries.