### PR TITLE
Implement error::Error on all error types

### DIFF
--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -1,4 +1,4 @@
-
+use std::error;
 use std::path::{Path, PathBuf};
 use std::fmt::{self, Display};
 use std::io;
@@ -120,6 +120,66 @@ impl<'a> Display for Notification<'a> {
             }
             NonFatalError(e) => write!(f, "{}", e),
             MissingInstalledComponent(c) => write!(f, "during uninstall component {} was not found", c),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match *self {
+            Utils(ref e) => error::Error::description(e),
+            Temp(ref e) => error::Error::description(e),
+            Manifest(ref e) => error::Error::description(e),
+            InvalidFileExtension => "invalid file extension",
+            InvalidInstaller => "invalid installer",
+            InvalidToolchainName => "invalid custom toolchain name",
+            NotInstalledHere => "not installed here",
+            InstallTypeNotPossible => "install type not possible",
+            UnsupportedHost(_) => "binary package not provided for host",
+            ChecksumFailed {..} => "checksum failed",
+            ComponentConflict {..} => "conflicting component",
+            ComponentMissingFile {..} => "missing file in component",
+            ComponentMissingDir {..} => "missing directory in component",
+            CorruptComponent(_) => "corrupt component manifest",
+            ExtractingPackage(_) => "failed to extract package",
+            ExtensionNotFound(_) => "could not find extension",
+            InvalidChangeSet => "invalid change-set",
+            NoGPG => "could not find 'gpg' on PATH",
+            BadInstallerVersion(_) => "unsupported installer version",
+            BadInstalledMetadataVersion(_) => "unsupported metadata version in existing installation",
+            ComponentDirPermissionsFailed(_) => "I/O error walking directory during install",
+            ComponentFilePermissionsFailed(_) => "error setting file permissions during install",
+            ComponentDownloadFailed(_, _) => "component download failed",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        use Error::*;
+        match *self {
+            Utils(ref e) => Some(e),
+            Temp(ref e) => Some(e),
+            Manifest(ref e) => Some(e),
+            ComponentFilePermissionsFailed(ref e) => Some(e),
+            ComponentDirPermissionsFailed(ref e) => Some(e),
+            ExtractingPackage(ref e) => Some(e),
+            ComponentDownloadFailed(_, ref e) => Some(e),
+            InvalidFileExtension |
+            InvalidInstaller |
+            InvalidToolchainName |
+            NotInstalledHere |
+            InstallTypeNotPossible |
+            UnsupportedHost(_) |
+            ChecksumFailed {..} |
+            ComponentConflict {..} |
+            ComponentMissingFile {..} |
+            ComponentMissingDir {..} |
+            CorruptComponent(_) |
+            ExtensionNotFound(_) |
+            InvalidChangeSet |
+            NoGPG |
+            BadInstallerVersion(_) |
+            BadInstalledMetadataVersion(_) => None,
         }
     }
 }

--- a/rust-install/src/temp.rs
+++ b/rust-install/src/temp.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::io;
@@ -91,6 +92,26 @@ impl<'a> Display for Notification<'a> {
                     write!(f, "could not delete temp directory: {}", path.display())
                 }
             }
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        use self::Error::*;
+        match *self {
+            CreatingRoot {..} => "could not create temp root",
+            CreatingFile {..} => "could not create temp file",
+            CreatingDirectory {..} => "could not create temp directory",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        use self::Error::*;
+        match *self {
+            CreatingRoot { ref error, .. } |
+            CreatingFile { ref error, .. } |
+            CreatingDirectory { ref error, .. } => Some(error),
         }
     }
 }

--- a/rust-install/src/utils/raw.rs
+++ b/rust-install/src/utils/raw.rs
@@ -1,4 +1,5 @@
 
+use std::error;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::io;
@@ -158,6 +159,28 @@ pub enum DownloadError {
 }
 pub type DownloadResult<T> = Result<T, DownloadError>;
 
+impl error::Error for DownloadError {
+    fn description(&self) -> &str {
+        use self::DownloadError::*;
+        match *self {
+            Status(_) => "unsuccessful HTTP status",
+            Network(ref e) => "network error",
+            File(ref e) => "error writing file",
+            FilePathParse => "failed to parse URL as file path",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        use self::DownloadError::*;
+        match *self {
+            Network(ref e) => Some(e),
+            File(ref e) => Some(e),
+            Status(_) |
+            FilePathParse => None,
+        }
+    }
+}
+
 impl fmt::Display for DownloadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -263,6 +286,24 @@ pub enum CommandError {
 }
 
 pub type CommandResult<T> = Result<T, CommandError>;
+
+impl error::Error for CommandError {
+    fn description(&self) -> &str {
+        use self::CommandError::*;
+        match *self {
+            Io(_) => "could not execute command",
+            Status(_) => "command exited with unsuccessful status",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        use self::CommandError::*;
+        match *self {
+            Io(ref e) => Some(e),
+            Status(_) => None,
+        }
+    }
+}
 
 impl fmt::Display for CommandError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/rust-manifest/src/errors.rs
+++ b/rust-manifest/src/errors.rs
@@ -1,5 +1,6 @@
 use toml;
 
+use std::error;
 use std::fmt::{self, Display};
 
 #[derive(Debug)]
@@ -11,6 +12,25 @@ pub enum Error {
     TargetNotFound(String),
     MissingRoot,
     UnsupportedVersion(String),
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        use self::Error::*;
+        match *self {
+            Parsing(_) => "error parsing manifest",
+            MissingKey(_) => "missing key",
+            ExpectedType(_, _) => "expected type",
+            PackageNotFound(_) => "package not found",
+            TargetNotFound(_) => "target not found",
+            MissingRoot => "manifest has no root package",
+            UnsupportedVersion(_) => "unsupported manifest version",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
+    }
 }
 
 impl Display for Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::error;
 use std::fmt::{self, Display};
 
 use rust_install::{self, utils, temp};
@@ -119,6 +120,42 @@ impl<'a> Display for Notification<'a> {
             WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{}'", ver),
             ReadMetadataVersion(ver) => write!(f, "read metadata version: '{}'", ver),
             NonFatalError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        use self::Error::*;
+        match *self {
+            Install(ref e) => error::Error::description(e),
+            Utils(ref e) => error::Error::description(e),
+            Temp(ref e) => error::Error::description(e),
+            UnknownMetadataVersion(_) => "unknown metadata version",
+            InvalidEnvironment => "invalid environment",
+            NoDefaultToolchain => "no default toolchain configured",
+            PermissionDenied => "permission denied",
+            ToolchainNotInstalled(_) => "toolchain is not installed",
+            UnknownHostTriple => "unknown host triple",
+            InfiniteRecursion =>  "infinite recursion detected",
+            Custom { ref desc, .. } => desc,
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        use Error::*;
+        match *self {
+            Install(ref e) => Some(e),
+            Utils(ref e) => Some(e),
+            Temp(ref e) => Some(e),
+            UnknownMetadataVersion(_) |
+            InvalidEnvironment |
+            NoDefaultToolchain |
+            PermissionDenied |
+            ToolchainNotInstalled(_) |
+            UnknownHostTriple |
+            InfiniteRecursion |
+            Custom {..} => None,
         }
     }
 }


### PR DESCRIPTION
This lets the `try!` macro work when using `Box<Error>` as a return
type.