### PR TITLE
Generalize create_command to take AsRef<OsStr>

### DIFF
--- a/rust-install/src/install.rs
+++ b/rust-install/src/install.rs
@@ -344,7 +344,7 @@ impl InstallPrefix {
         env_var::inc("RUST_RECURSION_COUNT", cmd);
     }
 
-    pub fn create_command(&self, binary: &str, cargo_home: &Path) -> Command {
+    pub fn create_command<T: AsRef<OsStr>>(&self, binary: T, cargo_home: &Path) -> Command {
         let mut cmd = Command::new(binary);
 
         self.set_env(&mut cmd, cargo_home);

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -189,7 +189,7 @@ impl<'a> Toolchain<'a> {
         self.set_env_inner(cmd);
     }
 
-    pub fn create_command(&self, binary: &str) -> Result<Command> {
+    pub fn create_command<T: AsRef<OsStr>>(&self, binary: T) -> Result<Command> {
         if !self.exists() {
             return Err(Error::ToolchainNotInstalled(self.name.to_owned()));
         }


### PR DESCRIPTION
This matches behavior of the underlying `Command::new()` call, and
allows passing command arguments from `env::args_os()` and elsewhere.