### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,8 +53,8 @@ impl Cfg {
         // Set up the multirust home directory
         let multirust_dir = env::var_os("MULTIRUST_HOME")
                                 .and_then(utils::if_not_empty)
-                                .map(PathBuf::from)
-                                .unwrap_or_else(|| data_dir.join(".multirust"));
+                                .map_or_else(|| data_dir.join(".multirust"), 
+                                             PathBuf::from);
 
         try!(utils::ensure_dir_exists("home", &multirust_dir, ntfy!(&notify_handler)));
 
@@ -87,8 +87,8 @@ impl Cfg {
         let dist_root_url = env::var("MULTIRUST_DIST_ROOT")
                                 .ok()
                                 .and_then(utils::if_not_empty)
-                                .map(Cow::Owned)
-                                .unwrap_or(Cow::Borrowed(dist::DEFAULT_DIST_ROOT));
+                                .map_or(Cow::Borrowed(dist::DEFAULT_DIST_ROOT),
+                                        Cow::Owned);
 
         Ok(Cfg {
             multirust_dir: multirust_dir,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -133,7 +133,7 @@ impl Display for Error {
                 write!(f,
                        "infinite recursion detected: the command may not exist for this toolchain")
             }
-            Custom { id: _, ref desc } => write!(f, "{}", desc),
+            Custom { ref desc, .. } => write!(f, "{}", desc),
         }
     }
 }


### PR DESCRIPTION
I left some warnings about inner items (in this case functions) after statements, because the functions are only there to distinguish between target OS and are near their call site. However, it would be possible to quell the warnings and move the functions out after the calling function.