### PR TITLE
Add a wrapper type to allow converting errors to Box<Error>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.project
 /target
 /Cargo.lock
+/errors/target
+/errors/Cargo.lock
 /rust-install/target
 /rust-install/Cargo.lock
 /rust-manifest/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["multirust", "install", "proxy"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+multirust-errors = { version = "0.0.1", path = "errors" }
 rust-install = { version = "0.0.4", path = "rust-install" }
 clap = "1.4.5"
 regex = "0.1.41"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "multirust-errors"
+version = "0.0.1"
+authors = ["Kamal Marhubi <kamal@marhubi.com>"]
+
+[dependencies]

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -1,0 +1,47 @@
+use std::any::Any;
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+
+/// Wrapper type that implements `Error` for "error" types that do not implement it themselves. The
+/// description from the `Display` impl is stored and used in the `Error` impl.
+#[derive(Debug)]
+pub struct Wrapped<E> {
+    inner: E,
+    desc: String,
+}
+
+impl<E> Wrapped<E> {
+    /// Get the inner error value of type `E`.
+    pub fn inner(&self) -> &E {
+        &self.inner
+    }
+    /// Get the stored description string.
+    pub fn desc(&self) -> &str {
+        &self.desc
+    }
+}
+
+impl<E: Display> From<E> for Wrapped<E> {
+    fn from(e: E) -> Wrapped<E> {
+        let desc = e.to_string();
+        Wrapped {
+            inner: e,
+            desc: desc,
+        }
+    }
+}
+
+impl<E: Display> Display for Wrapped<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.desc, f)
+    }
+}
+
+impl<E: Display + Debug + Any> Error for Wrapped<E> {
+    fn description(&self) -> &str {
+        &self.desc
+    }
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
+}

--- a/rust-install/Cargo.toml
+++ b/rust-install/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/Diggsey/multirust-rs"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+multirust-errors = { version = "0.0.1", path = "../errors" }
 regex = "0.1.41"
 rand = "0.3.11"
 hyper = "0.7.0"

--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -1,4 +1,4 @@
-
+use std::error;
 use std::path::{Path, PathBuf};
 use std::fmt::{self, Display};
 use std::io;
@@ -7,6 +7,7 @@ use utils;
 use rust_manifest;
 use walkdir;
 
+use multirust_errors::Wrapped;
 use notify::{NotificationLevel, Notifyable};
 use rust_manifest::Component;
 
@@ -190,5 +191,12 @@ impl Display for Error {
                 write!(f, "component download failed for {}-{}: {}", component.pkg, component.target, e)
             }
         }
+    }
+}
+
+/// This impl gets around `Error` not implementing `error::Error` itself.
+impl From<Error> for Box<error::Error> {
+    fn from(e: Error) -> Box<error::Error> {
+        Box::new(Wrapped::from(e))
     }
 }

--- a/rust-install/src/lib.rs
+++ b/rust-install/src/lib.rs
@@ -14,6 +14,7 @@ extern crate winreg;
 extern crate shell32;
 #[cfg(windows)]
 extern crate ole32;
+extern crate multirust_errors;
 extern crate rust_manifest;
 extern crate tempdir;
 extern crate walkdir;

--- a/rust-manifest/Cargo.toml
+++ b/rust-manifest/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/Diggsey/multirust-rs"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+multirust-errors = { version = "0.0.1", path = "../errors" }
 toml = "0.1.23"
 
 [lib]

--- a/rust-manifest/src/errors.rs
+++ b/rust-manifest/src/errors.rs
@@ -1,5 +1,7 @@
+use multirust_errors::Wrapped;
 use toml;
 
+use std::error;
 use std::fmt::{self, Display};
 
 #[derive(Debug)]
@@ -31,6 +33,13 @@ impl Display for Error {
             MissingRoot => write!(f, "manifest has no root package"),
             UnsupportedVersion(ref v) => write!(f, "manifest version '{}' is not supported", v),
         }
+    }
+}
+
+/// This impl gets around `Error` not implementing `error::Error` itself.
+impl From<Error> for Box<error::Error> {
+    fn from(e: Error) -> Box<error::Error> {
+        Box::new(Wrapped::from(e))
     }
 }
 

--- a/rust-manifest/src/lib.rs
+++ b/rust-manifest/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate toml;
+extern crate multirust_errors;
 
 pub use errors::*;
 pub use manifest::*;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,8 @@
-use std::path::Path;
+use std::error;
 use std::fmt::{self, Display};
+use std::path::Path;
 
+use multirust_errors::Wrapped;
 use rust_install::{self, utils, temp};
 use rust_install::notify::{self, NotificationLevel, Notifyable};
 
@@ -137,5 +139,12 @@ impl Display for Error {
             }
             Custom { ref desc, .. } => write!(f, "{}", desc),
         }
+    }
+}
+
+/// This impl gets around `Error` not implementing `error::Error` itself.
+impl From<Error> for Box<error::Error> {
+    fn from(e: Error) -> Box<error::Error> {
+        Box::new(Wrapped::from(e))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate rust_install;
+
+extern crate multirust_errors;
 extern crate rand;
 extern crate hyper;
 extern crate regex;


### PR DESCRIPTION
This makes it easier to use multirust and associated crates as
libraries. This does not implement `error::Error` directly on the error
types to avoid having to almost-duplicated the `Dispaly::fmt()`
implementation in `Error::description()`. Instead, it adds a wrapper
that uses the `Display` impl to create and store the description. For
more discussion, see
  https://github.com/Diggsey/multirust-rs/pull/60