### PR TITLE
config: Improve handling of upgrade-data when there is nothing to do

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -163,14 +163,16 @@ impl Cfg {
         let len = current_version.trim_right().len();
         current_version.truncate(len);
 
+        if current_version == METADATA_VERSION {
+            self.notify_handler
+                .call(Notification::MetadataUpgradeNotNeeded(METADATA_VERSION));
+            return Ok(false);
+        }
+
         self.notify_handler
             .call(Notification::UpgradingMetadata(&current_version, METADATA_VERSION));
 
         match &*current_version {
-            "2" => {
-                // Current version. Do nothing
-                Ok(false)
-            }
             "1" => {
                 // Ignore errors. These files may not exist.
                 let _ = fs::remove_dir_all(self.multirust_dir.join("available-updates"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,9 @@ impl Cfg {
             return Ok(false);
         }
 
-        let current_version = try!(utils::read_file("version", &self.version_file));
+        let mut current_version = try!(utils::read_file("version", &self.version_file));
+        let len = current_version.trim_right().len();
+        current_version.truncate(len);
 
         self.notify_handler
             .call(Notification::UpgradingMetadata(&current_version, METADATA_VERSION));

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,7 @@ pub enum Notification<'a> {
     ToolchainNotInstalled(&'a str),
 
     UpgradingMetadata(&'a str, &'a str),
+    MetadataUpgradeNotNeeded(&'a str),
     WritingMetadataVersion(&'a str),
     ReadMetadataVersion(&'a str),
     NonFatalError(&'a Error),
@@ -77,7 +78,8 @@ impl<'a> Notification<'a> {
             UninstallingToolchain(_) |
             UninstalledToolchain(_) |
             ToolchainNotInstalled(_) |
-            UpgradingMetadata(_, _) => NotificationLevel::Info,
+            UpgradingMetadata(_, _) |
+            MetadataUpgradeNotNeeded(_) => NotificationLevel::Info,
             NonFatalError(_) => NotificationLevel::Error,
         }
     }
@@ -110,6 +112,9 @@ impl<'a> Display for Notification<'a> {
                        "upgrading metadata version from '{}' to '{}'",
                        from_ver,
                        to_ver)
+            }
+            MetadataUpgradeNotNeeded(ver) => {
+                write!(f, "nothing to upgrade: metadata version is already '{}'", ver)
             }
             WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{}'", ver),
             ReadMetadataVersion(ver) => write!(f, "read metadata version: '{}'", ver),


### PR DESCRIPTION
This PR fixes the mishandling of a trailing whitespace in the `version` file, and improves the notification displayed to the user when there is nothing to upgrade.

Fixes #63