### PR TITLE
Download progress take 3

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,8 +53,7 @@ impl Cfg {
         // Set up the multirust home directory
         let multirust_dir = env::var_os("MULTIRUST_HOME")
                                 .and_then(utils::if_not_empty)
-                                .map_or_else(|| data_dir.join(".multirust"), 
-                                             PathBuf::from);
+                                .map_or_else(|| data_dir.join(".multirust"), PathBuf::from);
 
         try!(utils::ensure_dir_exists("home", &multirust_dir, ntfy!(&notify_handler)));
 
@@ -87,8 +86,7 @@ impl Cfg {
         let dist_root_url = env::var("MULTIRUST_DIST_ROOT")
                                 .ok()
                                 .and_then(utils::if_not_empty)
-                                .map_or(Cow::Borrowed(dist::DEFAULT_DIST_ROOT),
-                                        Cow::Owned);
+                                .map_or(Cow::Borrowed(dist::DEFAULT_DIST_ROOT), Cow::Owned);
 
         Ok(Cfg {
             multirust_dir: multirust_dir,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,7 +112,9 @@ impl<'a> Display for Notification<'a> {
                        to_ver)
             }
             MetadataUpgradeNotNeeded(ver) => {
-                write!(f, "nothing to upgrade: metadata version is already '{}'", ver)
+                write!(f,
+                       "nothing to upgrade: metadata version is already '{}'",
+                       ver)
             }
             WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{}'", ver),
             ReadMetadataVersion(ver) => write!(f, "read metadata version: '{}'", ver),

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
 fn run_inner<S: AsRef<OsStr>>(_: &Cfg, command: Result<Command>, args: &[S]) -> Result<()> {
     if let Ok(mut command) = command {
         for arg in &args[1..] {
-            if arg.as_ref() == <str as AsRef::<OsStr>>::as_ref("--multirust") {
+            if arg.as_ref() == <str as AsRef<OsStr>>::as_ref("--multirust") {
                 println!("Proxied via multirust");
                 std::process::exit(0);
             } else {
@@ -208,7 +208,7 @@ fn run_inner<S: AsRef<OsStr>>(_: &Cfg, command: Result<Command>, args: &[S]) -> 
 
     } else {
         for arg in &args[1..] {
-            if arg.as_ref() == <str as AsRef::<OsStr>>::as_ref("--multirust") {
+            if arg.as_ref() == <str as AsRef<OsStr>>::as_ref("--multirust") {
                 println!("Proxied via multirust");
                 std::process::exit(0);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,8 +142,8 @@ fn set_globals(m: Option<&ArgMatches>) -> Result<Cfg> {
                 // delete_line() doesn't seem to clear the line properly.
                 // Instead, let's just print some whitespace to clear it.
                 let _ = write!(t, "                ");
-                t.flush().unwrap();
-                t.carriage_return().unwrap();
+                let _ = t.flush();
+                let _ = t.carriage_return();
             }
             Notification::Install(In::Utils(Un::DownloadFinished)) => {
                 let dd = download_displayer.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,29 +75,102 @@ fn info_fmt(args: fmt::Arguments) {
 }
 
 fn set_globals(m: Option<&ArgMatches>) -> Result<Cfg> {
+	use std::rc::Rc;
+	use std::cell::{Cell, RefCell};
+
+	struct DownloadDisplayer {
+		content_len: Cell<Option<u64>>,
+		total_downloaded: Cell<usize>,
+		term: RefCell<Box<term::StdoutTerminal>>,
+	}
+
+	/// Human readable representation of data size in bytes
+	struct HumanReadable<T>(T);
+
+	impl<T: Into<f64> + Clone> fmt::Display for HumanReadable<T> {
+	    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	        const KIB: f64 = 1024.0;
+	        const MIB: f64 = 1048576.0;
+	        let size: f64 = self.0.clone().into();
+
+	        if size >= MIB {
+	            write!(f, "{:.2} MiB", size / MIB)
+	        } else if size >= KIB {
+	            write!(f, "{:.2} KiB", size / KIB)
+	        } else {
+	            write!(f, "{} B", size)
+	        }
+	    }
+	}
+
+	let download_displayer = Rc::new(DownloadDisplayer {
+		content_len: Cell::new(None),
+		total_downloaded: Cell::new(0),
+		term: RefCell::new(term::stdout().expect("Failed to open terminal.")),
+	});
+
     // Base config
     let verbose = m.map_or(false, |m| m.is_present("verbose"));
     Cfg::from_env(shared_ntfy!(move |n: Notification| {
         use multirust::notify::NotificationLevel::*;
-        match n.level() {
-            Verbose => {
-                if verbose {
-                    println!("{}", n);
-                }
-            }
-            Normal => {
-                println!("{}", n);
-            }
-            Info => {
-                info!("{}", n);
-            }
-            Warn => {
-                warn!("{}", n);
-            }
-            Error => {
-                err!("{}", n);
-            }
-        }
+		use rust_install::Notification as In;
+		use rust_install::utils::Notification as Un;
+
+		match n {
+			Notification::Install(In::Utils(Un::DownloadContentLengthReceived(len))) => {
+				let dd = download_displayer.clone();
+				dd.content_len.set(Some(len));
+				dd.total_downloaded.set(0);
+			}
+			Notification::Install(In::Utils(Un::DownloadDataReceived(len))) => {
+				let dd = download_displayer.clone();
+				let mut t = dd.term.borrow_mut();
+				dd.total_downloaded.set(dd.total_downloaded.get() + len);
+				let total_downloaded = dd.total_downloaded.get();
+				let total_h = HumanReadable(total_downloaded as f64);
+
+				match dd.content_len.get() {
+					Some(content_len) => {
+						let percent = (total_downloaded as f64 / content_len as f64) * 100.;
+						let content_len_h = HumanReadable(content_len as f64);
+						let _ = write!(t, "{} / {} ({:.2}%)", total_h, content_len_h, percent);
+					}
+					None => {
+						let _ = write!(t, "{}", total_h);
+					}
+				}
+				// delete_line() doesn't seem to clear the line properly.
+				// Instead, let's just print some whitespace to clear it.
+				let _ = write!(t, "                ");
+				t.flush().unwrap();
+				t.carriage_return().unwrap();
+			}
+			Notification::Install(In::Utils(Un::DownloadFinished)) => {
+				let dd = download_displayer.clone();
+				let _ = writeln!(dd.term.borrow_mut(), "");
+			}
+			n => {
+				match n.level() {
+		            Verbose => {
+		                if verbose {
+		                    println!("{}", n);
+		                }
+		            }
+		            Normal => {
+		                println!("{}", n);
+		            }
+		            Info => {
+		                info!("{}", n);
+		            }
+		            Warn => {
+		                warn!("{}", n);
+		            }
+		            Error => {
+		                err!("{}", n);
+		            }
+		        }
+			}
+		}
     }))
 
 }
@@ -227,7 +300,7 @@ fn run_multirust() -> Result<()> {
     let cfg = try!(set_globals(Some(&app_matches)));
 
     match app_matches.subcommand_name() {
-        Some("upgrade-data") | Some("delete-data") | Some("install") | 
+        Some("upgrade-data") | Some("delete-data") | Some("install") |
         Some("uninstall") | None => {} // Don't need consistent metadata
         Some(_) => {
             try!(cfg.check_metadata_version());
@@ -709,7 +782,7 @@ fn ask(question: &str) -> Option<bool> {
 }
 
 fn delete_data(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
-    if !m.is_present("no-prompt") && 
+    if !m.is_present("no-prompt") &&
        !ask("This will delete all toolchains, overrides, aliases, and other multirust data \
              associated with this user. Continue?")
             .unwrap_or(false) {


### PR DESCRIPTION
This implements the progress indication part of #71.

Since I don't know how to measure download speed without adding
another dependency (`time`), this only implements download progress display,
but not speed (which is less important).

# Library
The library part just adds the various notifications for the download events.
`Notification` implements `Display`, but download events aren't supposed to be
printed out normally, so the `Display` implementations for them aren't utilized right now.

# Client
To avoid having to implement architectural changes, I have once again opted for using `Rc` and friends. It shouldn't be a performance problem, but maybe someone has a better idea.

# Other
I also ran rustfmt in a follow-up commit to clean up after myself, which also affected some unrelated code.

Maybe the frequency of printing out the download events could be lessened (maybe once per second), but again, this would probably require something like the `time` crate.