### PR TITLE
Implement download speed and ETA information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ openssl = "0.7.2"
 hyper = "0.7.0"
 term = "0.2.11"
 itertools = "0.4.1"
+time = "0.1.34"
 
 [target.x86_64-pc-windows-gnu.dependencies]
 winapi = "0.2.4"

--- a/src/download_tracker.rs
+++ b/src/download_tracker.rs
@@ -97,7 +97,7 @@ impl DownloadTracker {
                     Cow::Borrowed("Unknown")
                 };
                 let _ = write!(&mut self.term,
-                               "{} / {} ({:.2}%) ~{}/s ETA: {}",
+                               "{} / {} ({:.2}%) {}/s ETA: {}",
                                total_h,
                                content_len_h,
                                percent,

--- a/src/download_tracker.rs
+++ b/src/download_tracker.rs
@@ -1,8 +1,7 @@
-use term;
-
-use std::fmt;
-use time::precise_time_s;
 use std::collections::VecDeque;
+use std::fmt;
+use term;
+use time::precise_time_s;
 
 /// Keep track of this many past download amounts
 const DOWNLOAD_TRACK_COUNT: usize = 5;

--- a/src/download_tracker.rs
+++ b/src/download_tracker.rs
@@ -1,0 +1,136 @@
+use term;
+
+use std::fmt;
+use time::precise_time_s;
+use std::collections::VecDeque;
+
+/// Keep track of this many past download amounts
+const DOWNLOAD_TRACK_COUNT: usize = 5;
+
+/// Tracks download progress and displays information about it to a terminal.
+pub struct DownloadTracker {
+    /// Content-Length of the to-be downloaded object.
+    content_len: Option<u64>,
+    /// Total data downloaded in bytes.
+    total_downloaded: usize,
+    /// Data downloaded this second.
+    downloaded_this_sec: usize,
+    /// Keeps track of amount of data downloaded every last few secs.
+    /// Used for averaging the download speed.
+    downloaded_last_few_secs: VecDeque<usize>,
+    /// Time stamp of the last second
+    last_sec: Option<f64>,
+    /// How many seconds have elapsed since the download started
+    seconds_elapsed: u32,
+    /// The terminal we write the information to.
+    term: Box<term::StdoutTerminal>,
+}
+
+impl DownloadTracker {
+    /// Creates a new DownloadTracker.
+    pub fn new() -> Self {
+        DownloadTracker {
+            content_len: None,
+            total_downloaded: 0,
+            downloaded_this_sec: 0,
+            downloaded_last_few_secs: VecDeque::with_capacity(DOWNLOAD_TRACK_COUNT),
+            seconds_elapsed: 0,
+            last_sec: None,
+            term: term::stdout().expect("Failed to open terminal"),
+        }
+    }
+    /// Notifies self that Content-Length information has been received.
+    pub fn content_length_received(&mut self, content_len: u64) {
+        self.content_len = Some(content_len);
+    }
+    /// Notifies self that data of size `len` has been received.
+    pub fn data_received(&mut self, len: usize) {
+        self.total_downloaded += len;
+        self.downloaded_this_sec += len;
+
+        match self.last_sec {
+            None => self.last_sec = Some(precise_time_s()),
+            Some(start) => {
+                let elapsed = precise_time_s() - start;
+                if elapsed >= 1.0 {
+                    self.seconds_elapsed += 1;
+
+                    self.display();
+                    self.last_sec = Some(precise_time_s());
+                    if self.downloaded_last_few_secs.len() == DOWNLOAD_TRACK_COUNT {
+                        self.downloaded_last_few_secs.pop_back();
+                    }
+                    self.downloaded_last_few_secs.push_front(self.downloaded_this_sec);
+                    self.downloaded_this_sec = 0;
+                }
+            }
+        }
+    }
+    /// Notifies self that the download has finished.
+    pub fn download_finished(&mut self) {
+        let _ = writeln!(&mut self.term, "");
+        self.last_sec = None;
+    }
+    /// Display the tracked download information to the terminal.
+    fn display(&mut self) {
+        let total_h = HumanReadable(self.total_downloaded as f64);
+
+        match self.content_len {
+            Some(content_len) => {
+                use std::borrow::Cow;
+
+                let percent = (self.total_downloaded as f64 / content_len as f64) * 100.;
+                let content_len_h = HumanReadable(content_len as f64);
+                let remaining = content_len - self.total_downloaded as u64;
+                let sum = self.downloaded_last_few_secs
+                              .iter()
+                              .fold(0usize, |a, &v| a + v);
+                let len = self.downloaded_last_few_secs.len();
+                let speed = if len > 0 {
+                    (sum / len) as u64
+                } else {
+                    0
+                };
+                let eta = if speed > 0 {
+                    Cow::Owned(format!("{}s", remaining / speed))
+                } else {
+                    Cow::Borrowed("Unknown")
+                };
+                let _ = write!(&mut self.term,
+                               "{} / {} ({:.2}%) ~{}/s ETA: {}",
+                               total_h,
+                               content_len_h,
+                               percent,
+                               HumanReadable(speed as f64),
+                               eta);
+            }
+            None => {
+                let _ = write!(&mut self.term, "{}", total_h);
+            }
+        }
+        // delete_line() doesn't seem to clear the line properly.
+        // Instead, let's just print some whitespace to clear it.
+        let _ = write!(&mut self.term, "                ");
+        let _ = self.term.flush();
+        let _ = self.term.carriage_return();
+    }
+}
+
+/// Human readable representation of data size in bytes
+struct HumanReadable<T>(T);
+
+impl<T: Into<f64> + Clone> fmt::Display for HumanReadable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KIB: f64 = 1024.0;
+        const MIB: f64 = 1048576.0;
+        let size: f64 = self.0.clone().into();
+
+        if size >= MIB {
+            write!(f, "{:.2} MiB", size / MIB)
+        } else if size >= KIB {
+            write!(f, "{:.2} KiB", size / KIB)
+        } else {
+            write!(f, "{} B", size)
+        }
+    }
+}

--- a/src/download_tracker.rs
+++ b/src/download_tracker.rs
@@ -68,6 +68,15 @@ impl DownloadTracker {
     /// Notifies self that the download has finished.
     pub fn download_finished(&mut self) {
         let _ = writeln!(&mut self.term, "");
+        self.prepare_for_new_download();
+    }
+    /// Resets the state to be ready for a new download.
+    fn prepare_for_new_download(&mut self) {
+        self.content_len = None;
+        self.total_downloaded = 0;
+        self.downloaded_this_sec = 0;
+        self.downloaded_last_few_secs.clear();
+        self.seconds_elapsed = 0;
         self.last_sec = None;
     }
     /// Display the tracked download information to the terminal.

--- a/src/download_tracker.rs
+++ b/src/download_tracker.rs
@@ -93,7 +93,7 @@ impl DownloadTracker {
     }
     /// Display the tracked download information to the terminal.
     fn display(&mut self) {
-        let total_h = HumanReadable(self.total_downloaded as f64);
+        let total_h = HumanReadable(self.total_downloaded as u64);
         let sum = self.downloaded_last_few_secs
                       .iter()
                       .fold(0usize, |a, &v| a + v);
@@ -103,14 +103,14 @@ impl DownloadTracker {
         } else {
             0
         };
-        let speed_h = HumanReadable(speed as f64);
+        let speed_h = HumanReadable(speed);
 
         match self.content_len {
             Some(content_len) => {
                 use std::borrow::Cow;
 
                 let percent = (self.total_downloaded as f64 / content_len as f64) * 100.;
-                let content_len_h = HumanReadable(content_len as f64);
+                let content_len_h = HumanReadable(content_len);
                 let remaining = content_len - self.total_downloaded as u64;
                 let eta = if speed > 0 {
                     Cow::Owned(format!("{}s", remaining / speed))
@@ -139,13 +139,13 @@ impl DownloadTracker {
 }
 
 /// Human readable representation of data size in bytes
-struct HumanReadable<T>(T);
+struct HumanReadable(u64);
 
-impl<T: Into<f64> + Clone> fmt::Display for HumanReadable<T> {
+impl fmt::Display for HumanReadable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KIB: f64 = 1024.0;
         const MIB: f64 = 1048576.0;
-        let size: f64 = self.0.clone().into();
+        let size = self.0 as f64;
 
         if size >= MIB {
             write!(f, "{:.2} MiB", size / MIB)


### PR DESCRIPTION
- Factor the download speed tracker out into its own module.
- Implement download speed and ETA tracking.
- Lessen the frequency at which we print the progress to the terminal to 1 Hz.

  This also has the side effect of not printing progress info for small downloads that complete
  quick, but I think that's unnecessary anyway.

Once merged, this will have dealt with #71 .