### PR TITLE
Next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rust-install = { version = "0.0.5", path = "rust-install" }
+rust-manifest = { version = "0.0.5", path = "rust-manifest" }
 clap = "1.4.5"
 regex = "0.1.41"
 rand = "0.3.11"

--- a/rust-install/src/dist.rs
+++ b/rust-install/src/dist.rs
@@ -30,7 +30,7 @@ pub struct ToolchainDesc {
 }
 
 impl ToolchainDesc {
-    pub fn from_str(name: &str) -> Option<Self> {
+    pub fn from_str(name: &str) -> Result<Self> {
         let archs = ["i686", "x86_64"];
         let oses = ["pc-windows", "unknown-linux", "apple-darwin"];
         let envs = ["gnu", "msvc"];
@@ -60,7 +60,7 @@ impl ToolchainDesc {
                 channel: c.at(4).unwrap().to_owned(),
                 date: c.at(5).and_then(fn_map),
             }
-        })
+        }).ok_or(Error::InvalidToolchainName(name.to_string()))
     }
 
     pub fn manifest_v1_url(&self, dist_root: &str) -> String {
@@ -267,7 +267,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                             ) -> Result<Option<String>> {
 
     let requested_toolchain = toolchain;
-    let ref toolchain = try!(ToolchainDesc::from_str(toolchain).ok_or(Error::InvalidToolchainName(toolchain.to_string())));
+    let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
     let trip = try!(toolchain.target_triple().ok_or_else(|| Error::UnsupportedHost(toolchain.full_spec())));
 
     let manifestation = try!(Manifestation::open(prefix.clone(), &trip));

--- a/rust-install/src/dist.rs
+++ b/rust-install/src/dist.rs
@@ -63,6 +63,25 @@ impl ToolchainDesc {
         }).ok_or(Error::InvalidToolchainName(name.to_string()))
     }
 
+    pub fn target_triple(&self) -> String {
+        let (host_arch, host_os, host_env) = get_host_triple();
+        let arch = self.arch.as_ref().map(|s| &**s).unwrap_or(host_arch);
+        let os = self.os.as_ref().map(|s| &**s).unwrap_or(host_os);
+        // Mixing arbitrary host envs into arbitrary target specs can't work sensibly.
+        // Only provide a default when the operating system matches.
+        let env = if self.env.is_none() && os == host_os {
+            host_env
+        } else {
+            self.env.as_ref().map(|s| &**s)
+        };
+
+        if let Some(ref env) = env {
+            format!("{}-{}-{}", arch, os, env)
+        } else {
+            format!("{}-{}", arch, os)
+        }
+    }
+
     pub fn manifest_v1_url(&self, dist_root: &str) -> String {
         match self.date {
             None => format!("{}/channel-rust-{}", dist_root, self.channel),
@@ -81,29 +100,8 @@ impl ToolchainDesc {
         }
     }
 
-    pub fn target_triple(&self) -> Option<String> {
-        let (host_arch, host_os, host_env) = get_host_triple();
-        let arch = self.arch.as_ref().map(|s| &**s).unwrap_or(host_arch);
-        let os = self.os.as_ref().map(|s| &**s).or(host_os);
-        // Mixing arbitrary host envs into arbitrary target specs can't work sensibly.
-        // Only provide a default when the operating system matches.
-        let env = if self.env.is_none() && os == host_os {
-            host_env
-        } else {
-            self.env.as_ref().map(|s| &**s)
-        };
-
-        os.map(|os| {
-            if let Some(ref env) = env {
-                format!("{}-{}-{}", arch, os, env)
-            } else {
-                format!("{}-{}", arch, os)
-            }
-        })
-    }
-
     pub fn full_spec(&self) -> String {
-        let triple = self.target_triple().unwrap_or_else(|| "<invalid target triple>".to_owned());
+        let triple = self.target_triple();
         if let Some(ref date) = self.date {
             format!("{}-{}-{}", triple, &self.channel, date)
         } else {
@@ -215,17 +213,17 @@ pub struct DownloadCfg<'a> {
     pub notify_handler: NotifyHandler<'a>,
 }
 
-pub fn get_host_triple() -> (&'static str, Option<&'static str>, Option<&'static str>) {
+pub fn get_host_triple() -> (&'static str, &'static str, Option<&'static str>) {
     let arch = match env::consts::ARCH {
         "x86" => "i686", // Why, rust... WHY?
         other => other,
     };
 
     let os = match env::consts::OS {
-        "windows" => Some("pc-windows"),
-        "linux" => Some("unknown-linux"),
-        "macos" => Some("apple-darwin"),
-        _ => None,
+        "windows" => "pc-windows",
+        "linux" => "unknown-linux",
+        "macos" => "apple-darwin",
+        _ => unimplemented!()
     };
 
     let env = match () {
@@ -268,8 +266,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
 
     let requested_toolchain = toolchain;
     let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
-    let trip = try!(toolchain.target_triple().ok_or_else(|| Error::UnsupportedHost(toolchain.full_spec())));
-
+    let trip = toolchain.target_triple();
     let manifestation = try!(Manifestation::open(prefix.clone(), &trip));
 
     let changes = Changes {
@@ -337,7 +334,7 @@ fn dl_v1_manifest<'a>(download: DownloadCfg<'a>,
     if !["nightly", "beta", "stable"].contains(&&*toolchain.channel) {
         // This is an explicit version. In v1 there was no manifest,
         // you just know the file to download, so synthesize one.
-        let trip = try!(toolchain.target_triple().ok_or_else(|| Error::UnsupportedHost(toolchain.full_spec())));
+        let trip = toolchain.target_triple();
         let installer_name = format!("{}/rust-{}-{}.tar.gz",
                                      root_url, toolchain.channel, trip);
         return Ok(vec![installer_name]);

--- a/rust-install/src/errors.rs
+++ b/rust-install/src/errors.rs
@@ -17,6 +17,7 @@ pub enum Notification<'a> {
 
     Extracting(&'a Path, &'a Path),
     UpdateHashMatches(&'a str),
+    ComponentAlreadyInstalled(&'a Component),
     CantReadUpdateHash(&'a Path),
     NoUpdateHash(&'a Path),
     ChecksumValid(&'a str),
@@ -94,7 +95,8 @@ impl<'a> Notification<'a> {
             Extracting(_, _) | ChecksumValid(_) | SignatureValid(_)  |
             InstallingToolchain(_) | DownloadingComponent(_, _) |
             InstallingComponent(_) => NotificationLevel::Normal,
-            UpdateHashMatches(_) | RollingBack => NotificationLevel::Info,
+            UpdateHashMatches(_) | ComponentAlreadyInstalled(_)  |
+            RollingBack => NotificationLevel::Info,
             CantReadUpdateHash(_) | ExtensionNotInstalled(_) |
             MissingInstalledComponent(_) => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
@@ -111,6 +113,10 @@ impl<'a> Display for Notification<'a> {
             Extracting(_, _) => write!(f, "extracting..."),
             UpdateHashMatches(hash) => {
                 write!(f, "update hash matches: {}, skipping update...", hash)
+            }
+            ComponentAlreadyInstalled(ref c) => {
+                write!(f, "component '{}' for target '{}' is up to date",
+                       c.pkg, c.target)
             }
             CantReadUpdateHash(path) => {
                 write!(f,

--- a/rust-install/src/mock/clitools.rs
+++ b/rust-install/src/mock/clitools.rs
@@ -275,7 +275,7 @@ fn build_mock_channel(channel: &str, date: &str,
 }
 
 pub fn this_host_triple(channel: &str) -> String {
-    ToolchainDesc::from_str(channel).and_then(|t| t.target_triple()).unwrap()
+    ToolchainDesc::from_str(channel).ok().and_then(|t| t.target_triple()).unwrap()
 }
 
 fn build_mock_std_installer(channel: &str) -> MockInstallerBuilder {

--- a/rust-install/src/mock/clitools.rs
+++ b/rust-install/src/mock/clitools.rs
@@ -275,7 +275,7 @@ fn build_mock_channel(channel: &str, date: &str,
 }
 
 pub fn this_host_triple(channel: &str) -> String {
-    ToolchainDesc::from_str(channel).ok().and_then(|t| t.target_triple()).unwrap()
+    ToolchainDesc::from_str(channel).ok().map(|t| t.target_triple()).unwrap()
 }
 
 fn build_mock_std_installer(channel: &str) -> MockInstallerBuilder {

--- a/rust-install/src/mock/clitools.rs
+++ b/rust-install/src/mock/clitools.rs
@@ -30,9 +30,20 @@ pub struct Config {
     pub customdir: TempDir,
 }
 
+// Describes all the features of the mock dist server.
+// Building the mock server is slow, so use simple scenario when possible.
+#[derive(PartialEq, Copy, Clone)]
+pub enum Scenario {
+    Full, // Two dates, two manifests, with cargo
+    ArchivesV2, // Two dates, no cargo, v2 manifests
+    ArchivesV1, // Two dates, no cargo, v2 manifests
+    SimpleV2, // One date, no cargo, v2 manifests
+    SimpleV1, // One date, no cargo, v1 manifests
+}
+
 /// Run this to create the test environment containing multirust, and
 /// a mock dist server.
-pub fn setup(vs: &[ManifestVersion], f: &Fn(&Config)) {
+pub fn setup(s: Scenario, f: &Fn(&Config)) {
     // Unset env variables that will break our testing
     env::remove_var("MULTIRUST_TOOLCHAIN");
 
@@ -43,7 +54,7 @@ pub fn setup(vs: &[ManifestVersion], f: &Fn(&Config)) {
         customdir: TempDir::new("multirust").unwrap(),
     };
 
-    create_mock_dist_server(&config.distdir.path(), vs);
+    create_mock_dist_server(&config.distdir.path(), s);
 
     let current_exe_path = env::current_exe().map(PathBuf::from).unwrap();
     let exe_dir = current_exe_path.parent().unwrap();
@@ -51,13 +62,14 @@ pub fn setup(vs: &[ManifestVersion], f: &Fn(&Config)) {
 
     let multirust_path = config.exedir.path().join(format!("multirust{}", EXE_SUFFIX));
     let rustc_path = config.exedir.path().join(format!("rustc{}", EXE_SUFFIX));
-    let rustdoc_path = config.exedir.path().join(format!("rustdoc{}", EXE_SUFFIX));
-    let cargo_path = config.exedir.path().join(format!("cargo{}", EXE_SUFFIX));
 
     fs::copy(multirust_build_path, multirust_path).unwrap();
     fs::copy(multirust_build_path, rustc_path).unwrap();
-    fs::copy(multirust_build_path, rustdoc_path).unwrap();
-    fs::copy(multirust_build_path, cargo_path).unwrap();
+
+    if s == Scenario::Full {
+        let cargo_path = config.exedir.path().join(format!("cargo{}", EXE_SUFFIX));
+        fs::copy(multirust_build_path, cargo_path).unwrap();
+    }
 
     // Create some custom toolchains
     create_custom_toolchains(config.customdir.path());
@@ -157,24 +169,37 @@ pub fn change_dir(path: &Path, f: &Fn()) {
 }
 
 // Creates a mock dist server populated with some test data
-fn create_mock_dist_server(path: &Path, vs: &[ManifestVersion]) {
-    let c1 = build_mock_channel("nightly", "2015-01-01", "1.2.0", "hash-n-1");
-    let c2 = build_mock_channel("beta", "2015-01-01", "1.1.0", "hash-b-1");
-    let c3 = build_mock_channel("stable", "2015-01-01", "1.0.0", "hash-s-1");
+fn create_mock_dist_server(path: &Path, s: Scenario) {
+    let mut chans = Vec::new();
+    if s == Scenario::Full || s == Scenario::ArchivesV1 || s == Scenario::ArchivesV2 {
+        let c1 = build_mock_channel("nightly", "2015-01-01", "1.2.0", "hash-n-1");
+        let c2 = build_mock_channel("beta", "2015-01-01", "1.1.0", "hash-b-1");
+        let c3 = build_mock_channel("stable", "2015-01-01", "1.0.0", "hash-s-1");
+        chans.extend(vec![c1, c2, c3]);
+    }
     let c4 = build_mock_channel("nightly", "2015-01-02", "1.3.0", "hash-n-2");
     let c5 = build_mock_channel("beta", "2015-01-02", "1.2.0", "hash-b-2");
     let c6 = build_mock_channel("stable", "2015-01-02", "1.1.0", "hash-s-2");
+    chans.extend(vec![c4, c5, c6]);
+
+    let ref vs = match s {
+        Scenario::Full => vec![ManifestVersion::V1, ManifestVersion::V2],
+        Scenario::SimpleV1 | Scenario::ArchivesV1 => vec![ManifestVersion::V1],
+        Scenario::SimpleV2 | Scenario::ArchivesV2 => vec![ManifestVersion::V2],
+    };
 
     MockDistServer {
         path: path.to_owned(),
-        channels: vec![c1, c2, c3, c4, c5, c6],
+        channels: chans,
     }.write(vs);
 
     // Also create the manifests for stable releases by version
-    let _ = fs::copy(path.join("dist/2015-01-01/channel-rust-stable.toml"),
-                     path.join("dist/channel-rust-1.0.0.toml"));
-    let _ = fs::copy(path.join("dist/2015-01-01/channel-rust-stable.toml.sha256"),
-                     path.join("dist/channel-rust-1.0.0.toml.sha256"));
+    if s == Scenario::Full || s == Scenario::ArchivesV1 || s == Scenario::ArchivesV2 {
+        let _ = fs::copy(path.join("dist/2015-01-01/channel-rust-stable.toml"),
+                         path.join("dist/channel-rust-1.0.0.toml"));
+        let _ = fs::copy(path.join("dist/2015-01-01/channel-rust-stable.toml.sha256"),
+                         path.join("dist/channel-rust-1.0.0.toml.sha256"));
+    }
     let _ = fs::copy(path.join("dist/2015-01-02/channel-rust-stable.toml"),
                      path.join("dist/channel-rust-1.1.0.toml"));
     let _ = fs::copy(path.join("dist/2015-01-02/channel-rust-stable.toml.sha256"),
@@ -182,10 +207,12 @@ fn create_mock_dist_server(path: &Path, vs: &[ManifestVersion]) {
 
     // Same for v1 manifests. These are just the installers.
     let host_triple = this_host_triple("stable");
-    fs::copy(path.join(format!("dist/2015-01-01/rust-stable-{}.tar.gz", host_triple)),
-             path.join(format!("dist/rust-1.0.0-{}.tar.gz", host_triple))).unwrap();
-    fs::copy(path.join(format!("dist/2015-01-01/rust-stable-{}.tar.gz.sha256", host_triple)),
-             path.join(format!("dist/rust-1.0.0-{}.tar.gz.sha256", host_triple))).unwrap();
+    if s == Scenario::Full || s == Scenario::ArchivesV1 || s == Scenario::ArchivesV2 {
+        fs::copy(path.join(format!("dist/2015-01-01/rust-stable-{}.tar.gz", host_triple)),
+                 path.join(format!("dist/rust-1.0.0-{}.tar.gz", host_triple))).unwrap();
+        fs::copy(path.join(format!("dist/2015-01-01/rust-stable-{}.tar.gz.sha256", host_triple)),
+                 path.join(format!("dist/rust-1.0.0-{}.tar.gz.sha256", host_triple))).unwrap();
+    }
     fs::copy(path.join(format!("dist/2015-01-02/rust-stable-{}.tar.gz", host_triple)),
              path.join(format!("dist/rust-1.1.0-{}.tar.gz", host_triple))).unwrap();
     fs::copy(path.join(format!("dist/2015-01-02/rust-stable-{}.tar.gz.sha256", host_triple)),
@@ -303,14 +330,11 @@ fn build_mock_cross_std_installer(_channel: &str, target: &str, date: &str) -> M
 
 fn build_mock_rustc_installer(version: &str, version_hash: &str) -> MockInstallerBuilder {
     let rustc = format!("bin/rustc{}", EXE_SUFFIX);
-    let rustdoc = format!("bin/rustdoc{}", EXE_SUFFIX);
     MockInstallerBuilder {
         components: vec![
             ("rustc".to_string(),
-             vec![MockCommand::File(rustc.clone()),
-                  MockCommand::File(rustdoc.clone())],
-             vec![(rustc, mock_bin("rustc", version, version_hash)),
-                  (rustdoc, mock_bin("rustdoc", version, version_hash))])
+             vec![MockCommand::File(rustc.clone())],
+             vec![(rustc, mock_bin("rustc", version, version_hash))])
                 ]
     }
 }

--- a/rust-install/src/mock/clitools.rs
+++ b/rust-install/src/mock/clitools.rs
@@ -192,8 +192,8 @@ fn create_mock_dist_server(path: &Path, vs: &[ManifestVersion]) {
              path.join(format!("dist/rust-1.1.0-{}.tar.gz.sha256", host_triple))).unwrap();
 }
 
-static CROSS_ARCH1: &'static str = "x86_64-unknown-linux-musl";
-static CROSS_ARCH2: &'static str = "arm-linux-androideabi";
+pub static CROSS_ARCH1: &'static str = "x86_64-unknown-linux-musl";
+pub static CROSS_ARCH2: &'static str = "arm-linux-androideabi";
 
 fn build_mock_channel(channel: &str, date: &str,
                       version: &'static str, version_hash: &str) -> MockChannel {

--- a/rust-install/tests/dist.rs
+++ b/rust-install/tests/dist.rs
@@ -279,7 +279,7 @@ fn update_from_dist(dist_server: &Url,
     let manifest = try!(Manifest::parse(&manifest_str));
 
     // Read the manifest to update the components
-    let trip = try!(toolchain.target_triple().ok_or_else(|| Error::UnsupportedHost(toolchain.full_spec())));
+    let trip = toolchain.target_triple();
     let manifestation = try!(Manifestation::open(prefix.clone(), &trip));
 
     let changes = Changes {
@@ -304,7 +304,7 @@ fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> Result<Url
 
 fn uninstall(toolchain: &ToolchainDesc, prefix: &InstallPrefix, temp_cfg: &temp::Cfg,
              notify_handler: NotifyHandler) -> Result<(), Error> {
-    let trip = try!(toolchain.target_triple().ok_or_else(|| Error::UnsupportedHost(toolchain.full_spec())));
+    let trip = toolchain.target_triple();
     let manifestation = try!(Manifestation::open(prefix.clone(), &trip));
 
     try!(manifestation.uninstall(temp_cfg, notify_handler.clone()));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,36 @@ r"Uninstalls an installed toolchain.
                 .arg(Arg::with_name("toolchain").required(true))
         )
         .subcommand(
+            SubCommand::with_name("list-targets")
+                .about("List targets available to install")
+                .after_help(
+r"List the targets available to an installed toolchain.
+"
+                )
+                .arg(Arg::with_name("toolchain").required(true))
+        )
+        .subcommand(
+            SubCommand::with_name("add-target")
+                .about("Add additional compilation targets to an existing toolchain")
+                .after_help(
+r"Adds the standard library for a given platform to an existing
+installation.
+"
+                )
+                .arg(Arg::with_name("toolchain").required(true))
+                .arg(Arg::with_name("target").required(true))
+        )
+        .subcommand(
+            SubCommand::with_name("remove-target")
+                .about("Removes compilation targets from an existing toolchain")
+                .after_help(
+r"Removes the standard library for a given platform.
+"
+                )
+                .arg(Arg::with_name("toolchain").required(true))
+                .arg(Arg::with_name("target").required(true))
+        )
+        .subcommand(
             SubCommand::with_name("run")
                 .setting(AppSettings::TrailingVarArg)
                 .about("Run a command.")

--- a/src/config.rs
+++ b/src/config.rs
@@ -273,7 +273,7 @@ impl Cfg {
                      .merge(["beta", "nightly", "stable"].into_iter().map(|s| (*s).to_owned()))
                      .dedup()
                      .filter(|name| {
-                         dist::ToolchainDesc::from_str(&name).ok().map(|d| d.is_tracking()) == Some(true)
+                         dist::ToolchainDesc::from_str(&name).map(|d| d.is_tracking()).ok() == Some(true)
                      })
                      .map(|name| {
                          let result = self.get_toolchain(&name, true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -273,7 +273,7 @@ impl Cfg {
                      .merge(["beta", "nightly", "stable"].into_iter().map(|s| (*s).to_owned()))
                      .dedup()
                      .filter(|name| {
-                         dist::ToolchainDesc::from_str(&name).map(|d| d.is_tracking()) == Some(true)
+                         dist::ToolchainDesc::from_str(&name).ok().map(|d| d.is_tracking()) == Some(true)
                      })
                      .map(|name| {
                          let result = self.get_toolchain(&name, true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate rust_install;
+extern crate rust_manifest;
 extern crate rand;
 extern crate hyper;
 extern crate regex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,14 +557,11 @@ fn self_uninstall(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 
 fn self_update(cfg: &Cfg, _m: &ArgMatches) -> Result<()> {
     // Get host triple
-    let triple = if let (arch, Some(os), maybe_env) = dist::get_host_triple() {
-        if let Some(env) = maybe_env {
-            format!("{}-{}-{}", arch, os, env)
-        } else {
-            format!("{}-{}", arch, os)
-        }
+    let (arch, os, maybe_env) = dist::get_host_triple();
+    let triple = if let Some(env) = maybe_env {
+        format!("{}-{}-{}", arch, os, env)
     } else {
-        return Err(Error::UnknownHostTriple);
+        format!("{}-{}", arch, os)
     };
 
     // Get download URL

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate rust_install;
+extern crate rust_manifest;
 
 #[macro_use]
 extern crate clap;
@@ -34,6 +35,7 @@ use std::thread;
 use std::time::Duration;
 use multirust::*;
 use rust_install::dist;
+use rust_manifest::Component;
 use openssl::crypto::hash::{Type, Hasher};
 use itertools::Itertools;
 use rust_install::notify::NotificationLevel;
@@ -300,6 +302,9 @@ fn run_multirust() -> Result<()> {
         ("list-toolchains", Some(_)) => list_toolchains(&cfg),
         ("remove-override", Some(m)) => remove_override(&cfg, m),
         ("remove-toolchain", Some(m)) => remove_toolchain_args(&cfg, m),
+        ("list-targets", Some(m)) => list_targets(&cfg, m),
+        ("add-target", Some(m)) => add_target(&cfg, m),
+        ("remove-target", Some(m)) => remove_target(&cfg, m),
         ("run", Some(m)) => run(&cfg, m),
         ("proxy", Some(m)) => proxy(&cfg, m),
         ("upgrade-data", Some(_)) => cfg.upgrade_data().map(|_| ()),
@@ -927,5 +932,43 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     } else {
         try!(update_all_channels(cfg))
     }
+    Ok(())
+}
+
+fn list_targets(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
+    let toolchain = m.value_of("toolchain").unwrap();
+    let toolchain = try!(cfg.get_toolchain(toolchain, false));
+    for component in try!(toolchain.list_components()) {
+        if component.pkg == "rust-std" {
+            println!("{}", component.target);
+        }
+    }
+
+    Ok(())
+}
+
+fn add_target(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
+    let toolchain = m.value_of("toolchain").unwrap();
+    let target = m.value_of("target").unwrap();
+    let toolchain = try!(cfg.get_toolchain(toolchain, false));
+    let new_component = Component {
+        pkg: "rust-std".to_string(),
+        target: target.to_string(),
+    };
+    try!(toolchain.add_component(new_component));
+
+    Ok(())
+}
+
+fn remove_target(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
+    let toolchain = m.value_of("toolchain").unwrap();
+    let target = m.value_of("target").unwrap();
+    let toolchain = try!(cfg.get_toolchain(toolchain, false));
+    let new_component = Component {
+        pkg: "rust-std".to_string(),
+        target: target.to_string(),
+    };
+    try!(toolchain.remove_component(new_component));
+
     Ok(())
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -236,7 +236,7 @@ impl<'a> Toolchain<'a> {
         // when the toolchain is created.
         let ref toolchain = self.name;
         let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
-        let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
+        let trip = toolchain.target_triple();
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 
         if let Some(manifest) = try!(manifestation.load_manifest()) {
@@ -266,7 +266,7 @@ impl<'a> Toolchain<'a> {
 
         let ref toolchain = self.name;
         let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
-        let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
+        let trip = toolchain.target_triple();
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 
         if let Some(manifest) = try!(manifestation.load_manifest()) {
@@ -309,7 +309,7 @@ impl<'a> Toolchain<'a> {
 
         let ref toolchain = self.name;
         let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
-        let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
+        let trip = toolchain.target_triple();
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 
         if let Some(manifest) = try!(manifestation.load_manifest()) {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -116,10 +116,10 @@ impl<'a> Toolchain<'a> {
                                                           self.download_cfg()))
     }
     pub fn is_custom(&self) -> bool {
-        dist::ToolchainDesc::from_str(&self.name).is_none()
+        ToolchainDesc::from_str(&self.name).is_err()
     }
     pub fn is_tracking(&self) -> bool {
-        dist::ToolchainDesc::from_str(&self.name).map(|d| d.is_tracking()) == Some(true)
+        ToolchainDesc::from_str(&self.name).ok().map(|d| d.is_tracking()) == Some(true)
     }
 
     pub fn ensure_custom(&self) -> Result<()> {
@@ -235,7 +235,7 @@ impl<'a> Toolchain<'a> {
         // FIXME: This toolchain handling is a mess. Just do it once
         // when the toolchain is created.
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain).ok_or(rust_install::Error::InvalidToolchainName(toolchain.to_string())));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
         let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 
@@ -265,7 +265,7 @@ impl<'a> Toolchain<'a> {
         }
 
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain).ok_or(rust_install::Error::InvalidToolchainName(toolchain.to_string())));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
         let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 
@@ -308,7 +308,7 @@ impl<'a> Toolchain<'a> {
         }
 
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain).ok_or(rust_install::Error::InvalidToolchainName(toolchain.to_string())));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
         let trip = try!(toolchain.target_triple().ok_or_else(|| rust_install::Error::UnsupportedHost(toolchain.full_spec())));
         let manifestation = try!(Manifestation::open(self.prefix.clone(), &trip));
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -3,15 +3,14 @@
 
 extern crate rust_install;
 
-use rust_install::mock::dist::ManifestVersion;
-use rust_install::mock::clitools::{self, Config,
+use rust_install::mock::clitools::{self, Config, Scenario,
                                    expect_stdout_ok, expect_stderr_ok,
                                    expect_ok, expect_err, run,
                                    this_host_triple};
 use rust_install::utils;
 
 pub fn setup(f: &Fn(&Config)) {
-    clitools::setup(&[ManifestVersion::V2], f);
+    clitools::setup(Scenario::SimpleV2, f);
 }
 
 #[test]
@@ -445,7 +444,7 @@ fn custom_remote_url() {
 
 #[test]
 fn custom_multiple_local_path() {
-    setup(&|config| {
+    clitools::setup(Scenario::Full, &|config| {
         let trip = this_host_triple("nightly");
         let custom_installer1 = config.distdir.path().join(
             format!("dist/2015-01-01/rustc-nightly-{}.tar.gz", trip));
@@ -465,7 +464,7 @@ fn custom_multiple_local_path() {
 
 #[test]
 fn custom_multiple_remote_url() {
-    setup(&|config| {
+    clitools::setup(Scenario::Full, &|config| {
         let trip = this_host_triple("nightly");
         let custom_installer1 = config.distdir.path().join(
             format!("dist/2015-01-01/rustc-nightly-{}.tar.gz", trip));

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -6,15 +6,14 @@ extern crate tempdir;
 
 use std::fs;
 use tempdir::TempDir;
-use rust_install::mock::dist::ManifestVersion;
-use rust_install::mock::clitools::{self, Config,
+use rust_install::mock::clitools::{self, Config, Scenario,
                                    expect_ok, expect_stdout_ok, expect_err,
                                    expect_stderr_ok, set_current_dist_date,
                                    change_dir, run};
 use rust_install::utils;
 
 pub fn setup(f: &Fn(&Config)) {
-    clitools::setup(&[ManifestVersion::V1], f);
+    clitools::setup(Scenario::SimpleV1, f);
 }
 
 #[test]
@@ -47,8 +46,6 @@ fn expected_bins_exist() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "1.3.0");
-        expect_stdout_ok(config, &["rustdoc", "--version"], "1.3.0");
-        expect_stdout_ok(config, &["cargo", "--version"], "1.3.0");
     });
 }
 
@@ -66,7 +63,7 @@ fn install_toolchain_from_channel() {
 
 #[test]
 fn install_toolchain_from_archive() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["multirust", "default" , "nightly-2015-01-01"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
         expect_ok(config, &["multirust", "default" , "beta-2015-01-01"]);
@@ -95,7 +92,7 @@ fn default_existing_toolchain() {
 
 #[test]
 fn update_channel() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"],
@@ -109,7 +106,7 @@ fn update_channel() {
 
 #[test]
 fn list_toolchains() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "update", "beta-2015-01-01"]);
         expect_stdout_ok(config, &["multirust", "list-toolchains"],
@@ -208,7 +205,7 @@ fn install_override_toolchain_from_channel() {
 
 #[test]
 fn install_override_toolchain_from_archive() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["multirust", "override", "nightly-2015-01-01"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-n-1");
@@ -405,7 +402,7 @@ fn no_update_on_channel_when_date_has_not_changed() {
 
 #[test]
 fn update_on_channel_when_date_has_changed() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"],
@@ -419,7 +416,7 @@ fn update_on_channel_when_date_has_changed() {
 
 #[test]
 fn update_no_toolchain_means_update_all_toolchains() {
-    setup(&|config| {
+    clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["multirust", "update"]);
 


### PR DESCRIPTION
Add `list-targets`, `add-target`, `remove-target` commands

`list-target <toolchain>` lists all the rust-std components available
for an installed toolchain.

`add-target <toolchain> <target>` adds the rust-std component
for a given target to an installed toolchain.

`remove-target` does the opposite.

This code mostly lives in `multirust_rs::toolchain`. I think it probably should live in `rust_install::dist`, but haven't gotten done with the refactoring.

I removed some of the work done by the cli tests, and on linux here the tests go from 39s to 23s. On windows the wins should be even better.

I'll mostly be doing refactoring and cleanup for the rest of the week.