### PR TITLE
Change toolchain override message from info to warn

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -790,7 +790,7 @@ async fn default_(
         if let Some((toolchain, source)) = cfg.active_toolchain()?
             && !matches!(source, ActiveSource::Default)
         {
-            info!(
+            warn!(
                 "note that the toolchain '{toolchain}' is currently in use ({})",
                 source.to_reason()
             );

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -324,7 +324,7 @@ async fn default_override() {
         .with_stderr(snapbox::str![[r#"
 info: using existing install for stable-[HOST_TRIPLE]
 info: default toolchain set to stable-[HOST_TRIPLE]
-info: note that the toolchain 'nightly-[HOST_TRIPLE]' is currently in use (directory override for '[..]')
+warn: note that the toolchain 'nightly-[HOST_TRIPLE]' is currently in use (directory override for '[..]')
 
 "#]])
         .is_ok();


### PR DESCRIPTION
Problem:
rustup currently logs an info-level message when a rust-toolchain.toml file overrides the active toolchain. This message is easy to miss in CI logs, leading to confusion when the expected toolchain (e.g., beta) isn’t being used.

Fix:
Promote the message about toolchain override (rust-toolchain.toml) from info to warn level, making it more visible during builds and CI runs.

Fix https://github.com/rust-lang/rustup/issues/4504
