### PR TITLE
Use `cc-rs` to detect the default linker, instead of assuming `cc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ test = ["dep:snapbox", "dep:walkdir", "clap-cargo/testing_colors"]
 anstream = "1"
 anstyle = "1.0.11"
 anyhow = "1.0.69"
+cc = "1"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help", "string"] }
@@ -112,7 +113,6 @@ snapbox = { version = "1", features = ["term-svg"], optional = true }
 walkdir = { version = "2", optional = true }
 
 [target."cfg(windows)".dependencies]
-cc = "1"
 scopeguard = "1"
 windows-registry = "0.6"
 windows-result = "0.4"

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -828,20 +828,47 @@ fn current_install_opts(opts: &InstallOpts<'_>, process: &Process) -> String {
 
 #[cfg(unix)]
 fn warn_if_default_linker_missing(process: &Process) {
-    // Search for `cc` in PATH
-    if let Some(path) = process.var_os("PATH") {
-        let cc_binary = format!("cc{}", EXE_SUFFIX);
+    // Search for linker in PATH
+    let Some(path) = process.var_os("PATH") else {
+        warn!("unable to search PATH for a default linker");
+        warn!("many Rust crates require a system C toolchain to build");
+        return;
+    };
 
-        for mut p in env::split_paths(&path) {
-            p.push(&cc_binary);
-            if p.is_file() {
-                return;
-            }
-        }
+    // If we have the host triple, attempt to determine the CC/linker path that
+    // `cc-rs` would use, as this is *usually* why we need a linker to invoke.
+    //
+    // Doing it this way allows us to correctly diagnose quirky systems like
+    // solaris and illumos that use `gcc` rather than `cc` for historical reasons.
+    let cc_tool = TargetTriple::from_host(process).and_then(|triple| {
+        // Fill in some dummy settings for `Build`/`Tool` to be able to properly
+        // give us the metadata we want
+        cc::Build::new()
+            .opt_level(0)
+            .target(&triple)
+            .host(&triple)
+            .try_get_compiler()
+            .ok()
+    });
+
+    let cc_binary = if let Some(cc_tool) = &cc_tool {
+        Cow::Borrowed(cc_tool.path())
+    } else {
+        // If we don't get info from cc-rs, fall back to just looking for the literal `cc`.
+        Cow::Owned(format!("cc{EXE_SUFFIX}").into())
+    };
+
+    // Search the path for the selected binary
+    let found = env::split_paths(&path).any(|mut p| {
+        p.push(&cc_binary);
+        p.is_file()
+    });
+
+    if !found {
+        let bin_disp = cc_binary.display();
+        warn!("no default linker (`{bin_disp}`) was found in your PATH");
+        warn!("many Rust crates require a system C toolchain to build");
     }
-
-    warn!("no default linker (`cc`) was found in your PATH");
-    warn!("many Rust crates require a system C toolchain to build");
 }
 
 fn install_bins(process: &Process) -> Result<()> {

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -133,6 +133,9 @@ impl Assert {
                 ("[CROSS_ARCH_I]", Cow::Borrowed(CROSS_ARCH1)),
                 ("[CROSS_ARCH_II]", Cow::Borrowed(CROSS_ARCH2)),
                 ("[MULTI_ARCH_I]", Cow::Borrowed(MULTI_ARCH1)),
+                ("[CC_TOOL]", Cow::Borrowed("`cc`")),
+                ("[CC_TOOL]", Cow::Borrowed("`gcc`")),
+                ("[CC_TOOL]", Cow::Borrowed("`clang`")),
             ])
             .expect("invalid redactions detected");
         Self {

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -684,7 +684,7 @@ async fn install_warns_if_default_linker_missing() {
         .is_ok()
         .with_stderr(snapbox::str![[r#"
 ...
-warn: no default linker (`cc`) was found in your PATH
+warn: no default linker ([CC_TOOL]) was found in your PATH
 warn: many Rust crates require a system C toolchain to build
 ...
 "#]]);


### PR DESCRIPTION
On hosts like `illumos`, `cc` is not present in the path, leading to misleading warnings like:

```
warn: no default linker (`cc`) was found in your PATH
warn: many Rust crates require a system C toolchain to build
```

However, there is a linker present: `gcc`. Since this warning at install time is to help ensure the system is prepared to do build.rs work, which typically uses `cc-rs`, and has this additional metadata for targets, this PR uses the `cc-rs` infra directly to determine the correct binary to search for. If `cc-rs` has nothing to say about our particular host, we fall back to the existing "just look for `cc` in PATH" logic.

There's a *little* unfortunate song and dance required, as `cc-rs` doesn't make this information directly available (requiring you to create a `Build`, which then requires some information like opt-level and host/target triples to get the correct tool path), if this isn't palatable, I can follow up with `cc-rs` to see if they want to make this metadata a bit more directly obtainable.

I'm not sure the best way to directly test the rustup install process using this branch, if there are docs somewhere I'm happy to run and verify the warning is skipped now on illumos targets.