### PR TITLE
Improve error message for incomplete toolchains

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -71,7 +71,11 @@ pub enum RustupError {
     DownloadingFile { url: Url, path: PathBuf },
     #[error("could not download file from '{url}' to '{}'", .path.display())]
     DownloadNotExists { url: Url, path: PathBuf },
-    #[error("Missing manifest in toolchain '{}'", .0)]
+    #[error(
+        "missing manifest in toolchain '{0}'\n\
+     help: this may happen if the toolchain installation was interrupted\n\
+     help: try reinstalling or updating the toolchain"
+    )]
     MissingManifest(ToolchainDesc),
     #[error("server sent a broken manifest: missing package for component {0}")]
     MissingPackageForComponent(String),

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -4144,3 +4144,35 @@ installed targets:
         .with_stderr(snapbox::str![[""]])
         .is_ok();
 }
+
+#[tokio::test]
+async fn missing_manifest_shows_reinstall_help() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    cx.config
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .is_ok();
+
+    let manifest_path = cx
+        .config
+        .rustupdir
+        .join("toolchains")
+        .join(format!("nightly-{}", this_host_triple()))
+        .join("lib")
+        .join("rustlib")
+        .join("multirust-channel-manifest.toml");
+
+    fs::remove_file(&manifest_path).unwrap();
+
+    cx.config
+        .expect(["rustup", "component", "list", "--toolchain", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: missing manifest in toolchain 'nightly-[HOST_TRIPLE]'
+help: this may happen if the toolchain installation was interrupted
+help: try reinstalling or updating the toolchain
+
+"#]])
+        .is_err();
+}


### PR DESCRIPTION
Improve the error message shown when `rustup` encounters a toolchain that is missing its manifest.

Interrupted installations can leave a partially installed toolchain behind. Rustup already improves the recovery experience when reinstalling such toolchains (#4725), but users can still encounter a confusing "Missing manifest" error when interacting with the incomplete toolchain before retrying installation.

- Added a test that removes the manifest file from an installed toolchain and verifies the improved error message

Related to #4724
Builds on the interrupted-install UX improvements from #4725