### PR TITLE
docs: fix "initial" spelling in stylesheet variable

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -58,7 +58,7 @@
     --platform-button-background-color: var(--gray);
     --platform-button-color: var(--white);
     --copy-button-text-color: var(--rustup-teal);
-    --rust-logo-filter: initital;
+    --rust-logo-filter: initial;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Fix a typo in `www/rustup.css` by changing `initital` to `initial`.

## Related issue
- N/A (trivial typo fix)

## Guideline alignment
- Followed contribution guidance from README and the Rustup dev guide.
- Single-file, docs-only correction.

## Validation
- Not run; docs/CSS text-only change.