### PR TITLE
test(dist/manifest): use the reordered fixture in `manifest_serialized_with_sorted_keys`

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -656,7 +656,7 @@ mod tests {
     static EXAMPLE: &str = include_str!("manifest/tests/channel-rust-nightly-example.toml");
     // Same manifest as above, but with the packages in a different order.
     static EXAMPLE_REORDERED: &str =
-        include_str!("manifest/tests/channel-rust-nightly-example.toml");
+        include_str!("manifest/tests/channel-rust-nightly-example-reordered.toml");
     // From brson's live build-rust-manifest.py script
     static EXAMPLE2: &str = include_str!("manifest/tests/channel-rust-nightly-example2.toml");
 


### PR DESCRIPTION
The regression test for #4715 was meant to parse two TOML manifests with packages declared in different orders and assert that their serialized forms are identical, proving keys are emitted in deterministic (sorted) order. However, `EXAMPLE_REORDERED` was `include_str!`-ing the same file as `EXAMPLE`, so the assertion held trivially and the test never actually exercised the sort-on-serialize behavior. 

This PR points it at the existing `channel-rust-nightly-example-reordered.toml` fixture so the test can catch any future regression that breaks deterministic manifest serialization.